### PR TITLE
Headings with subtext need a margin

### DIFF
--- a/src/main/java/com/github/gwtbootstrap/client/ui/Heading.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/Heading.java
@@ -116,7 +116,11 @@ public class Heading extends ComplexWidget implements HasText {
 	 */
 	public void setText(String text) {
 		this.text = text;
-		getElement().setInnerHTML(text + small.toString());
+
+	    // Add a space after the main heading text to get the same effect as Twitter Bootstrap.
+        // <h1>Some text <small>Some subtext</small></h1>
+        //              ^- Note the space
+		getElement().setInnerHTML(text + " " + small.toString());
 	}
 
 	/**


### PR DESCRIPTION
I was comparing your showcase to the original one over att Twitter Bootstrap and saw that there is no margin between a heading and the subtext (the kind of thing that really stands out to me, maybe not to others).

I first thaought that there was somthing different in the CSS. After a quick look in the HTML a saw that they actually insert a space before the small tag. That seems smart since that will make the margin scale with the font size. This pull request is an attempt to fix that.

Please remove the comment in the code if it doesn’t seem nessescary, I just thought an explanation for the extra space was good for future programmers.
