### PR TITLE
Return from ListBox's setSelectedValue after finding the first match.

### DIFF
--- a/src/main/java/com/github/gwtbootstrap/client/ui/ListBox.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/ListBox.java
@@ -143,6 +143,7 @@ public class ListBox extends com.google.gwt.user.client.ui.ListBox implements Ha
 		for(int i = 0; i < getItemCount(); i++) {
 			if (getValue(i).equals(value)) {
 				setSelectedIndex(i);
+				return;
 			}
 		}
 	}


### PR DESCRIPTION
Right now if multiple equal values exist, the last one gets selected. Maybe it'll be better if it would return after finding the first match?

Fixing my own mistake :)

Raidok
