### PR TITLE
Format for DateBox should use only lowercase letters

### DIFF
--- a/src/main/java/com/github/gwtbootstrap/datepicker/client/ui/base/DateBoxBase.java
+++ b/src/main/java/com/github/gwtbootstrap/datepicker/client/ui/base/DateBoxBase.java
@@ -83,7 +83,7 @@ public class DateBoxBase extends Widget implements HasValue<Date>, HasValueChang
         this.box = new TextBox();
         this.language = LocaleUtil.getLanguage();
         setElement(box.getElement());
-        setFormat(DateTimeFormat.getFormat(DateTimeFormat.PredefinedFormat.DATE_MEDIUM).getPattern());
+        setFormat(DateTimeFormat.getFormat(DateTimeFormat.PredefinedFormat.DATE_SHORT).getPattern().toLowerCase());
         setWeekStart(LocaleInfo.getCurrentLocale().getDateTimeFormatInfo().firstDayOfTheWeek());
         setValue(new Date());
     }


### PR DESCRIPTION
In bootstrap datepicker component lowercase letters are used to define pattern.
But, DateTimeFormat uses 'MM' for month. 
