### PR TITLE
bugfix: SplitDropdrownButton has overridden setText, but not getText

### DIFF
--- a/src/main/java/com/github/gwtbootstrap/client/ui/SplitDropdownButton.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/SplitDropdownButton.java
@@ -70,6 +70,14 @@ public class SplitDropdownButton extends DropdownBase implements
 		button.setText(text);
 	}
 
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public String getText() {
+		return button.getText();
+	}
+
 	@Override
 	protected IconAnchor createTrigger() {
 		button = new Button();


### PR DESCRIPTION
-> fixed! :)
