### PR TITLE
Alternate size and alignment in DateBoxAppended

### DIFF
--- a/src/main/java/com/github/gwtbootstrap/datepicker/client/ui/DateBoxAppended.java
+++ b/src/main/java/com/github/gwtbootstrap/datepicker/client/ui/DateBoxAppended.java
@@ -17,9 +17,11 @@ package com.github.gwtbootstrap.datepicker.client.ui;
 
 import com.github.gwtbootstrap.client.ui.AppendButton;
 import com.github.gwtbootstrap.client.ui.base.AddOn;
+import com.github.gwtbootstrap.client.ui.base.HasAlternateSize;
 import com.github.gwtbootstrap.client.ui.base.HasIcon;
 import com.github.gwtbootstrap.client.ui.base.HasVisibility;
 import com.github.gwtbootstrap.client.ui.base.HasVisibleHandlers;
+import com.github.gwtbootstrap.client.ui.constants.AlternateSize;
 import com.github.gwtbootstrap.client.ui.constants.BaseIconType;
 import com.github.gwtbootstrap.client.ui.constants.IconPosition;
 import com.github.gwtbootstrap.client.ui.constants.IconSize;
@@ -39,19 +41,21 @@ import com.google.gwt.event.logical.shared.HasValueChangeHandlers;
 import com.google.gwt.event.logical.shared.ValueChangeHandler;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.ui.HasValue;
+import com.google.gwt.user.client.ui.ValueBoxBase.TextAlignment;
 
 import java.util.Date;
 
 /**
  * DateBoxAppended component.
- * 
+ *
  * @since 2.0.4.0
  * @author Carlos Alexandro Becker
  */
 public class DateBoxAppended extends AppendButton implements HasValue<Date>,
         HasDateFormat, HasIcon, HasValueChangeHandlers<Date>, HasVisibility,
         HasChangeHandlers, HasVisibleHandlers, HasAllDatePickerHandlers,
-        IsEditor<TakesValueEditor<Date>> {
+        HasAlternateSize, IsEditor<TakesValueEditor<Date>> {
+
     /**
      * An 'adapter' to change some aspects of the behavior of datepickerbase.
      */
@@ -75,7 +79,7 @@ public class DateBoxAppended extends AppendButton implements HasValue<Date>,
         add(icon);
     }
 
-    
+
     /**
      * {@inheritDoc}
      */
@@ -98,6 +102,18 @@ public class DateBoxAppended extends AppendButton implements HasValue<Date>,
     @Override
     public void setValue(Date value, boolean fireEvents) {
         box.setValue(value, fireEvents);
+    }
+
+     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setAlternateSize(AlternateSize size) {
+        box.setAlternateSize(size);
+    }
+
+    public void setAlignment(TextAlignment align) {
+        box.setAlignment(align);
     }
 
     /**
@@ -151,7 +167,7 @@ public class DateBoxAppended extends AppendButton implements HasValue<Date>,
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @deprecated
      */
     @Override

--- a/src/main/java/com/github/gwtbootstrap/datepicker/client/ui/base/DateBoxBase.java
+++ b/src/main/java/com/github/gwtbootstrap/datepicker/client/ui/base/DateBoxBase.java
@@ -58,6 +58,7 @@ import com.google.gwt.i18n.client.LocaleInfo;
 import com.google.gwt.user.client.Event;
 import com.google.gwt.user.client.ui.HasEnabled;
 import com.google.gwt.user.client.ui.HasValue;
+import com.google.gwt.user.client.ui.ValueBoxBase.TextAlignment;
 import com.google.gwt.user.client.ui.Widget;
 
 /**
@@ -87,6 +88,10 @@ public class DateBoxBase extends Widget implements HasValue<Date>,HasEnabled, Ha
         setFormat(DateTimeFormat.getFormat(DateTimeFormat.PredefinedFormat.DATE_SHORT).getPattern().toLowerCase());
         setWeekStart(LocaleInfo.getCurrentLocale().getDateTimeFormatInfo().firstDayOfTheWeek());
         setValue(new Date());
+    }
+
+    public void setAlignment(TextAlignment align) {
+        box.setAlignment(align);
     }
 
     /**


### PR DESCRIPTION
This patch adds some small but useful features.

DateBoxAppended can now set an alternate size and alignment for the textbox. DateBoxBase can now also set the alignment for the textbox.
