### PR TITLE
FIX: 'consume' validation errors after displaying to avoid duplicated messages

### DIFF
--- a/src/main/java/com/github/gwtbootstrap/client/ui/base/ValueBoxBase.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/base/ValueBoxBase.java
@@ -77,6 +77,7 @@ public class ValueBoxBase<T> extends com.google.gwt.user.client.ui.ValueBoxBase<
 			SafeHtmlBuilder sb = new SafeHtmlBuilder();
 			for (EditorError error : errors) {
 				if(error.getEditor() == this) {
+					error.setConsumed(true);
 					sb.appendEscaped(error.getMessage());
 					sb.appendHtmlConstant("<br />");
 				}


### PR DESCRIPTION
Fixes duplicated messages issue commented on #323

GWT generates an Error for each editor available (one for the EditorDriver one for the TextBox) so they mus be marked as consumed once they are displayed
