### PR TITLE
Fix modal centerVertically

### DIFF
--- a/src/main/java/com/github/gwtbootstrap/client/ui/Modal.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/Modal.java
@@ -549,6 +549,7 @@ public class Modal extends DivWidget implements HasVisibility, HasVisibleHandler
 	 */
 	private native void centerVertically(Element e) /*-{
 		$wnd.jQuery(e).css("margin-top", (-1 * $wnd.jQuery(e).outerHeight() / 2) + "px");
+		$wnd.jQuery(e).css("top", "50%");
 	}-*/;
 
 }


### PR DESCRIPTION
Modal dialogs were appearing off the screen because 'top' wasn't being set.
