### PR TITLE
Added support for custom highligthers in Typeahead.

### DIFF
--- a/src/main/java/com/github/gwtbootstrap/client/ui/Typeahead.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/Typeahead.java
@@ -22,7 +22,11 @@ public class Typeahead extends MarkupWidget {
     public interface UpdaterCallback {
         String onSelection(Suggestion selectedSuggestion);
     }
-    
+
+    public interface HighlighterCallback {
+        String highlight(String item);
+    }
+
     private int displayItems = 8;
 
     private int minLength = 1;
@@ -31,6 +35,7 @@ public class Typeahead extends MarkupWidget {
     private Collection<? extends Suggestion> suggestions;
 
     private UpdaterCallback updaterCallback;
+    private HighlighterCallback highlighterCallback;
 
     /**
      * Constructor for {@link Typeahead}. Creates a {@link MultiWordSuggestOracle} to use with this
@@ -47,6 +52,7 @@ public class Typeahead extends MarkupWidget {
     public Typeahead(SuggestOracle oracle) {
         this.oracle = oracle;
         this.updaterCallback = createDefaultUpdaterCallback();
+        this.highlighterCallback = createDefaultHighlighterCallback();
     }
 
     private UpdaterCallback createDefaultUpdaterCallback() {
@@ -54,6 +60,15 @@ public class Typeahead extends MarkupWidget {
             @Override
             public String onSelection(Suggestion selectedSuggestion) {
                 return selectedSuggestion.getReplacementString();
+            }
+        };
+    }
+
+    private HighlighterCallback createDefaultHighlighterCallback() {
+        return new HighlighterCallback() {
+            @Override
+            public String highlight(String item) {
+                return item;
             }
         };
     }
@@ -141,6 +156,11 @@ public class Typeahead extends MarkupWidget {
         this.updaterCallback = updaterCallback;
     }
 
+    public void setHighlighterCallback(
+            HighlighterCallback highlighterCallback) {
+        this.highlighterCallback = highlighterCallback;
+    }
+
     /**
      * Get suggest oracle
      *
@@ -185,7 +205,11 @@ public class Typeahead extends MarkupWidget {
 
         return item;
     }
-    
+
+    private String highlighter(String item) {
+        return this.highlighterCallback.highlight(item);
+    }
+
     //@formatter:off
     private native void callProcess(JsArrayString items ,JavaScriptObject process) /*-{
         process(items);
@@ -208,7 +232,7 @@ public class Typeahead extends MarkupWidget {
                 return that.@com.github.gwtbootstrap.client.ui.Typeahead::updater(Ljava/lang/String;)(item);
             },
             "highlighter" : function(item) {
-                return item;
+                return that.@com.github.gwtbootstrap.client.ui.Typeahead::highlighter(Ljava/lang/String;)(item);
             }
         });
     }-*/;

--- a/src/main/java/com/github/gwtbootstrap/client/ui/resources/ResourceInjector.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/resources/ResourceInjector.java
@@ -65,14 +65,15 @@ public class ResourceInjector {
         INJECTOR.preConfigure();
 
         Resources res = ADAPTER.getResources();
+        if(isNotLoadedJquery()) 
+            injectJs(res.jquery());
+
+        injectCss(res.bootstrapCss());
+        injectJs(res.bootstrapJs());
+
         if (ADAPTER.hasResponsiveDesign())
             activateResponsiveDesign(res);
 
-        if(isNotLoadedJquery()) 
-            injectJs(res.jquery());
-        
-        injectJs(res.bootstrapJs());
-        
         INJECTOR.configure();
     }
 

--- a/src/main/java/com/github/gwtbootstrap/client/ui/resources/css/gwt-bootstrap.css
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/resources/css/gwt-bootstrap.css
@@ -1,6 +1,4 @@
 body { padding-top: 50px; }
-a.btn {color:#333333;}
-a.btn-primary, a.btn-warning, a.btn-danger, a.btn-success, a.btn-info, a.btn-inverse {color:#ffffff;}
 div.input-prepend>input,textarea,select,.uneditable-input { margin-bottom: 0; }
 div.input-append>input,textarea,select,.uneditable-input { margin-bottom: 0; }
 .gwt-PopupPanel .gwt-DatePicker { width: 200px; }


### PR DESCRIPTION
A couple of smaller fixes, which I'm less certain of:
- Removed forced colors on a.btn which seems to interfere with third-party
  bootstrap themes.
- The bootstrap-responsive.css is now injected last to make it work in
  Chrome. In particular,  on smaller screens, `TextBox` wouldn't resize and `ControlLabel` wouldn't break from the adjacent input field.

It might be of interest that I've been experimenting with third-party bootstrap themes, as opposed to only relying on the default one, and that could be the reason why I'm seeing problems that others have not.
