### PR TITLE
Fixed Heading ui binder example

### DIFF
--- a/src/main/java/com/github/gwtbootstrap/client/ui/Heading.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/Heading.java
@@ -29,7 +29,7 @@ import com.google.gwt.user.client.ui.HasText;
  * 
  * <pre>
  * {@code 
- * <b:Heading size="2" text="And I'm the subtext">I'm the heading</b:Heading>}
+ * <b:Heading size="2" subtext="And I'm the subtext">I'm the heading</b:Heading>}
  * </pre>
  * Specifying the <code>size</code> is mandatory.
  * </p>


### PR DESCRIPTION
The example for Heading should contain subtext not text attribute. With the text attribute it just overrides the content of the heading.
