### PR TITLE
fix for #263 Esc does not close Modal

### DIFF
--- a/src/main/java/com/github/gwtbootstrap/client/ui/Modal.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/Modal.java
@@ -105,6 +105,7 @@ public class Modal extends DivWidget implements HasVisibility, HasVisibleHandler
 	 */
 	public Modal() {
 		super("modal");
+		getElement().setAttribute("tabindex", "-1");
 		super.add(header);
 		super.add(body);
 		setVisible(false);


### PR DESCRIPTION
Added tabindex=-1 to constructor of modal. Fixes "#263 Esc does not close Modal". 
: getElement().setAttribute("tabindex", "-1");

( A doubt : What if we want the modal to get focus, say when we're designing something for accessibility).
