### PR TITLE
Add missing IMPORTANT to badge-type enum

### DIFF
--- a/src/main/java/com/github/gwtbootstrap/client/ui/constants/BadgeType.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/constants/BadgeType.java
@@ -32,7 +32,8 @@ import com.github.gwtbootstrap.client.ui.base.Style;
 public enum BadgeType implements Style {
 
 	DEFAULT(""), SUCCESS("badge-success"), WARNING("badge-warning"), ERROR(
-			"badge-error"), INFO("badge-info"), INVERSE("badge-inverse");
+			"badge-error"), INFO("badge-info"), INVERSE("badge-inverse"),
+			IMPORTANT("badge-important");
 
 	private static final String badge = "badge ";
 


### PR DESCRIPTION
I guess this just got forgotten.
