### PR TITLE
Button looses icon when loading state is changed

### DIFF
--- a/src/main/java/com/github/gwtbootstrap/client/ui/Button.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/Button.java
@@ -15,10 +15,7 @@
  */
 package com.github.gwtbootstrap.client.ui;
 
-import com.github.gwtbootstrap.client.ui.base.HasType;
-import com.github.gwtbootstrap.client.ui.base.IconAnchor;
-import com.github.gwtbootstrap.client.ui.base.NavbarButton;
-import com.github.gwtbootstrap.client.ui.base.StyleHelper;
+import com.github.gwtbootstrap.client.ui.base.*;
 import com.github.gwtbootstrap.client.ui.constants.ButtonType;
 import com.github.gwtbootstrap.client.ui.constants.Constants;
 import com.github.gwtbootstrap.client.ui.constants.DismissType;
@@ -291,9 +288,16 @@ public class Button extends IconAnchor implements HasClickHandlers,
 			setLoadingBehavior("complete");
 		}
 
-		private void setLoadingBehavior(String behavior) {
-			setLoadingBehavior(getElement(), behavior);
-		}
+        private void setLoadingBehavior(String behavior) {
+            // Remove icon because it will be removed by Bootstrap's "$(element).button(behavior)" anyway
+            icon.removeFromParent();
+
+            setLoadingBehavior(getElement(), behavior);
+
+            // Recreate icon and add it to inner content with setText()
+            icon = new Icon(icon.getIconType());
+            setText(getElement().getInnerText());
+        }
 
 		private native void setLoadingBehavior(Element e, String behavior) /*-{
 			$wnd.jQuery(e).button(behavior);

--- a/src/main/java/com/github/gwtbootstrap/client/ui/base/IconAnchor.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/base/IconAnchor.java
@@ -63,11 +63,12 @@ import com.google.gwt.user.client.ui.impl.FocusImpl;
  * @author Dominik Mayer
  * @author ohashi keisuke
  */
-public class IconAnchor extends ComplexWidget implements HasText, HasIcon, HasHref, HasClickHandlers, HasEnabled, Focusable, HasName, HasMouseDownHandlers {
+public class IconAnchor extends ComplexWidget implements HasText, HasIcon, HasHref, HasClickHandlers, HasEnabled,
+        Focusable, HasName, HasMouseDownHandlers {
 
     private static final FocusImpl impl = FocusImpl.getFocusImplForWidget();
 
-	private Icon icon = new Icon();
+	protected Icon icon = new Icon();
 
 	private TextNode text = new TextNode("");
 


### PR DESCRIPTION
UiBinder XML:

```
<b:Button ui:field='save' icon='SAVE' text='Save' loadingText='Saving...' completeText='Saved'/>
```

Java:

```
saveButton.state().loading();
...
saveButton.state().complete();
```

Icon is gone afterwards. Only new loading state text is displayed.
I think this happens because in [Bootstrap JavaScript](http://twitter.github.io/bootstrap/javascript.html#buttons)

```
$(element).button("loading")
```

replaces the whole contents of the button with the loading state text.

I've tried to fix this by calling `setIconPosition()` in `Button.LoadingStateBehavior#setLoadingBehavior()` but got an `UmbrellaException`?!
