### PR TITLE
Set the Collapse widget as collapse while its initialization

### DIFF
--- a/src/main/java/com/github/gwtbootstrap/client/ui/Collapse.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/Collapse.java
@@ -124,7 +124,7 @@ public class Collapse extends MarkupWidget implements HasVisibility, HasVisibleH
                     if(!isExistTrigger()){
                         reconfigure();
                     } else {
-			configure(widget.getElement(), parent, toggle);
+                        configure(widget.getElement(), parent, toggle);
                         setHandlerFunctions(widget.getElement());
                     }
                 }


### PR DESCRIPTION
Just place this initialization in order to ensure the DOM element is set as a collapse at its first append.
