### PR TITLE
Name for GWTBootstrap-FormPanel will be generated differently to GWT-FormPanel which will prevent name conflicts

### DIFF
--- a/src/main/java/com/github/gwtbootstrap/client/ui/Form.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/Form.java
@@ -299,7 +299,7 @@ public class Form extends ComplexWidget implements FormPanelImplHost {
 			// We use the module name as part of the unique ID to ensure that
 			// ids are
 			// unique across modules.
-			frameName = "FormPanel_" + GWT.getModuleName() + "_" + (++formId);
+			frameName = "BSFormPanel_" + GWT.getModuleName() + "_" + (++formId);
 			setTarget(frameName);
 
 			sinkEvents(Event.ONLOAD);


### PR DESCRIPTION
Referencing Issue #363
