### PR TITLE
SuggestBox Typeahead CSS

### DIFF
--- a/src/main/java/com/github/gwtbootstrap/client/ui/resources/css/gwt-bootstrap.css
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/resources/css/gwt-bootstrap.css
@@ -6,3 +6,30 @@ div.input-append>input,div.input-append>textarea,div.input-append>select,div.inp
 .gwt-SuggestBoxPopup .suggestPopupTop { background-color: white; }
 .gwt-SuggestBoxPopup .suggestPopupMiddle { background-color: white; }
 .gwt-SuggestBoxPopup .suggestPopupBottomCenter { background-color: white; }
+.gwt-SuggestBoxPopup .item {
+    /*padding: 2px 6px;
+    color: #000;*/
+    cursor: pointer;
+    font-size: 110%;
+
+    /*display: block;*/
+    padding: 3px 9px;
+    clear: both;
+    font-weight: normal;
+    line-height: 20px;
+    color: #333333;
+    white-space: nowrap;
+}
+.gwt-SuggestBoxPopup .item-selected {
+    color: #ffffff;
+    text-decoration: none;
+    background-color: #0081c2;
+    background-image: -moz-linear-gradient(top, #0088cc, #0077b3);
+    background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#0088cc), to(#0077b3));
+    background-image: -webkit-linear-gradient(top, #0088cc, #0077b3);
+    background-image: -o-linear-gradient(top, #0088cc, #0077b3);
+    background-image: linear-gradient(to bottom, #0088cc, #0077b3);
+    background-repeat: repeat-x;
+    outline: 0;
+    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff0088cc', endColorstr='#ff0077b3', GradientType=0);
+}


### PR DESCRIPTION
I've added Typeahead's CSS style applied to GWT SuggestBox in gwt-bootstrap.css file, attempting to https://github.com/gwtbootstrap/gwt-bootstrap/issues/432.

Also I've fixed some bugs in this css file. Textarea and Select were receiving padding-bottom 0 always. But the correct is only when in prepend or append context.
