### PR TITLE
NavCollapse has fixed height on first collapse

### DIFF
--- a/src/main/java/com/github/gwtbootstrap/client/ui/NavCollapse.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/NavCollapse.java
@@ -16,7 +16,7 @@
 package com.github.gwtbootstrap.client.ui;
 
 import com.github.gwtbootstrap.client.ui.base.DivWidget;
-import com.github.gwtbootstrap.client.ui.resources.Bootstrap;
+import com.github.gwtbootstrap.client.ui.constants.Constants;
 
 //@formatter:off
 /**
@@ -58,7 +58,7 @@ public class NavCollapse extends DivWidget {
 	 * Creates an empty widget.
 	 */
 	public NavCollapse() {
-		super(Bootstrap.nav_collapse);
+		super(Constants.NAV_COLLAPSE);
 	}
 
 }

--- a/src/main/java/com/github/gwtbootstrap/client/ui/ResponsiveNavbar.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/ResponsiveNavbar.java
@@ -20,7 +20,6 @@ import com.github.gwtbootstrap.client.ui.base.NavbarButton;
 import com.github.gwtbootstrap.client.ui.config.Configurator;
 import com.github.gwtbootstrap.client.ui.constants.Constants;
 import com.github.gwtbootstrap.client.ui.constants.IconType;
-import com.github.gwtbootstrap.client.ui.resources.Bootstrap;
 import com.google.gwt.user.client.ui.Widget;
 
 //@formatter:off
@@ -70,7 +69,7 @@ import com.google.gwt.user.client.ui.Widget;
 public class ResponsiveNavbar extends Navbar {
 
 	private final NavbarButton collapseButton = new NavbarButton();
-	private final DivWidget navCollapse = new DivWidget("nav-collapse");
+	private final DivWidget navCollapse = new DivWidget(Constants.NAV_COLLAPSE);
 
 	/**
 	 * Creates an empty widget.
@@ -82,9 +81,9 @@ public class ResponsiveNavbar extends Navbar {
 
     private void addCollapseButton() {
 		collapseButton.getElement().setAttribute(Constants.DATA_TOGGLE,
-				Bootstrap.collapse);
-		collapseButton.getElement().setAttribute(Bootstrap.data_target,
-				Bootstrap.nav_collapse_target);
+				Constants.COLLAPSE);
+		collapseButton.getElement().setAttribute(Constants.DATA_TARGET,
+				Constants.NAV_COLLAPSE_TARGET);
 		collapseButton.add(new Icon(IconType.BAR));
 		collapseButton.add(new Icon(IconType.BAR));
 		collapseButton.add(new Icon(IconType.BAR));

--- a/src/main/java/com/github/gwtbootstrap/client/ui/constants/Constants.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/constants/Constants.java
@@ -189,6 +189,10 @@ public interface Constants {
     public static final String ACCORDION_INNER = "accordion-inner";
 
     public static final String COLLAPSE = "collapse";
+    
+    public static final String NAV_COLLAPSE = "nav_collapse " + COLLAPSE;
+    
+	public static final String NAV_COLLAPSE_TARGET = ".nav-collapse";
 
     public static final String IN = "in";
 

--- a/src/main/java/com/github/gwtbootstrap/client/ui/resources/Bootstrap.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/resources/Bootstrap.java
@@ -94,14 +94,6 @@ public interface Bootstrap {
 
 	public static final String footer = "footer";
 
-	public static final String nav_collapse = "nav-collapse";
-
-	public static final String nav_collapse_target = "." + nav_collapse;
-
-	public static final String collapse = "collapse";
-
-	public static final String data_target = "data-target";
-
 	public enum Tabs implements Style {
 
 		ABOVE(""),


### PR DESCRIPTION
There is an issue when using a ResponsiveNavbar containing Dropdowns.

When the screen is too small, there is that NavbarButton that appears to collapse hidden content and when you collapse the content <b>the first time</b>, the NavCollapse that holds the content will have a fixed height size. Therefore when clicking on a dropdown, the size won't adapt and some of the content will be hidden.

If we fold the content and collapse it again, it works as it should.

This issue can be reproduced with the Navbar that's on the [demo page](http://gwtbootstrap.github.io/#component:navigation)

Basically the issue is the same as the one described [here](http://stackoverflow.com/questions/14735747/bootstrap-responsive-collapsed-submenu-has-fixed-height-on-first-collapse) and the fix for it is the same.
