### PR TITLE
use GWT.getModuleBaseURL() to load resources in injectResourceCssAsFile.

### DIFF
--- a/src/main/java/com/github/gwtbootstrap/client/ui/resources/ResourceInjector.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/resources/ResourceInjector.java
@@ -92,7 +92,7 @@ public class ResourceInjector {
         LinkElement link = Document.get().createLinkElement();
         link.setType("text/css");
         link.setRel("stylesheet");
-        link.setHref(GWT.getModuleName() + "/css/" + filename);
+        link.setHref(GWT.getModuleBaseURL() + "css/" + filename);
         getHead().appendChild(link);
     }
 


### PR DESCRIPTION
I've updated ResourceInjector to use GWT.getModuleBaseURL() to load the css files. GWT.getModuleName() only includes the module name, which fails to load the css file if the project's servlet is not mapped to a top-level directory.

GWT.getModuleName() = mygwtproject/css/bootstrap.min.css
GWT.getModuleBaseURL() = http://myhost.com/more/dirs/mygwtproject/css/bootstrap.min.css

GWT.getModuleNameURL() also guarantees a trailing slash.
