### PR TITLE
ResourceInjector was not respecting custom bootstrap css files. Fixed by

### DIFF
--- a/src/main/java/com/github/gwtbootstrap/client/ui/Resources.gwt.xml
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/Resources.gwt.xml
@@ -19,9 +19,6 @@
 <!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.4.0//EN"
         "http://google-web-toolkit.googlecode.com/svn/tags/2.4.0/distro-source/core/src/gwt-module.dtd">
 <module>
-    <stylesheet src="css/bootstrap.min.css"/>
-    <stylesheet src="css/gwt-bootstrap.css"/>
-    <stylesheet src="css/font-awesome.min.css"/>
     <public path="resources">
         <exclude name="**/*.java"/>
         <exclude name="**/*.class"/>

--- a/src/main/java/com/github/gwtbootstrap/client/ui/config/Configurator.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/config/Configurator.java
@@ -20,73 +20,77 @@ import com.github.gwtbootstrap.client.ui.resources.Resources;
 
 /**
  * <h3>Using custom CSS/JS resources.</h3>
- * 
+ *
  * <p>
- * GWT-Bootstrap uses embedded copies of bootstrap.css and bootstrap.js by default. If you need to use your own copies
- * or include other resources, you'll need to create a custom {@link Configurator} and a custom {@link Resources}.
- * </p>
- * <p>
- * A suggested layout is below. First, create your resource package at the same level as client/server/shared. Next, create
- * css and js directories beneath the resources directory, and add your custom css and js files into those. Next, create your custom
- * {@link Configurator} and a custom {@link Resources}. Finally, add
- * a <code>replace-with</code> tag and a <code>public</code> tag to your module xml.
+ * GWT-Bootstrap uses embedded copies of bootstrap.css and bootstrap.js by default. If you need to use your own custom copies,
+ * you'll need to create a custom {@link Configurator} and a custom {@link Resources}.
  * </p>
  * <p>
  * Full example below:
  * </p>
- * 
  * <p>
- * 1. Create your resources package directory and add css and js directories beneath that. Add your custom css and js files to the css and js
- * directories, respectively.
+ * 1. First, in the src/main/java tree, create a resources package at the same level as client/server/shared.
+ * Your custom {@link Configurator} and custom {@link Resources} will be placed in this resources package.
  * <pre>
  * src/main/java/com/example
  * |-- client
  * |-- resources
- * |   |-- css
- * |   |   `-- bootstrap.min.css < your custom css
- * |   |   `-- bootstrap-responsive.min.css < your custom css
- * |   |-- js
- * |   |   `-- bootstrap.min.js < your custom js
- * |   |-- ExampleConfigurator.java < your custom Configurator class
- * |   `-- ExampleResources.java < your custom Resources interface
+ * |   |-- ExampleResources.java < your custom Resources interface, see step 3
+ * |   |-- ExampleConfigurator.java < your custom Configurator class, see step 4
  * |-- server
  * |-- shared
- * `-- Example.gwt.xml < your module xml file
+ * |-- Example.gwt.xml < your module xml file
  * </pre>
- * 
- * 
- * 2. Create a Resources interface (extending {@link Resources}) that overrides the
- * getters of the files you want to replace.
- * 
+ * </p>
+ *
+ * <p>
+ * 2. In the src/main/resources tree, create a directory structure that matches the one in src/main/java, so
+ * src/main/resources/com/example/resources/. Beneath there, create css and js directories, and add your custom css and js files
+ * into those.
  * <pre>
- * 	public interface MyResources extends Resources {
- * 		{@literal @Source("css/bootstrap.min.css")}
+ * src/main/resources/com/example
+ * |-- resources
+ * |   |-- css
+ * |   |   |-- bootstrap-custom.css < your custom css
+ * |   |   |-- bootstrap-responsive-custom.css < your custom css
+ * |   |-- js
+ * |   |   |-- bootstrap-custom.js < your custom js
+ * </pre>
+ *
+ * 3. Create a Resources interface (extending {@link Resources}) that overrides the
+ * getters of the files you want to replace. Place in src/main/java/com/example.
+ *
+ * <pre>
+ *  package com.example.resources;
+ * 	public interface ExampleResources extends Resources {
+ * 		{@literal @Source("com/example/resources/css/bootstrap-custom.css")}  < name anything you like, path must match the layout above
  * 		TextResource bootstrapCss();
  *
- * 		{@literal @Source("css/bootstrap-responsive.min.css")}
+ * 		{@literal @Source("com/example/resources/css/bootstrap-responsive-custom.css")} < name anything you like, path must match the layout above
  * 		TextResource bootstrapResponsiveCss();
  * 	}
  * </pre>
- * 
+ *
  * </p>
- * 
+ *
  * <p>
- * 3. Create a <code>Configurator</code> that returns your new {@link Resources}.
- * 
+ * 4. Create a <code>Configurator</code> that returns your new {@link Resources}. Place in src/main/java/com/example.
+ *
  * <pre>
- * 	public MyConfigurator implements Configurator {
+ *  package com.example.resources;
+ * 	public ExampleConfigurator implements Configurator {
  * 		public Resources getResources() {
- * 			return GWT.create(MyResources.class);
+ * 			return GWT.create(ExampleResources.class);
  * 		}
  * 	}
  * </pre>
- * 
+ *
  * </p>
- * 
+ *
  * <p>
- * 4. Add a <code>replace-with</code> tag, a <code>source</code> tag, and a <code>public</code> tag to your module xml
+ * 5. Add a <code>replace-with</code> tag, a <code>source</code> tag, and a <code>public</code> tag to your module xml
  * (<code>*.gwt.xml</code>):
- * 
+ *
  * <pre>
  * {@literal
  * <source path='resources'/>
@@ -100,16 +104,17 @@ import com.github.gwtbootstrap.client.ui.resources.Resources;
  *
  * }
  * </pre>
- * 
+ *
  * </p>
  *
  * <p>A more detailed tutorial and a full working example can be found <a href="http://carlosbecker.com/posts/using-a-custom-bootstrap-theme-in-gwt-bootstrap">here</a>.</p>
  * @since 2.0.4.0
- * 
+ *
  * @author Dominik Mayer
  * @author ohashi keisuke
  * @author Carlos A Becker
- * 
+ * @author Greg Sheremeta
+ *
  * @see Resources
  * @see DefaultConfigurator
  */
@@ -117,7 +122,7 @@ public interface Configurator {
 
 	/**
 	 * Get the Bootstrap Resources that should be used for this project.
-	 * 
+	 *
 	 * @return the Bootstrap Resources
 	 */
 	Resources getResources();
@@ -125,18 +130,18 @@ public interface Configurator {
 	//@formatter:off
 	/**
 	 * Determines whether the project uses a responsive design.
-	 * 
+	 *
 	 * <p>
 	 * If the responsive
 	 * design is enabled, the interface can adapt to the screen size and show
 	 * different content on smartphones, tablets and desktop computers.
 	 * </p>
-	 * 
+	 *
 	 * @return <code>true</code> if the responsive features should be enabled.
 	 * Default: <code>false</code>
-	 * 
+	 *
 	 * @see IsResponsive
-	 * 
+	 *
 	 * @see <a href="http://twitter.github.com/bootstrap/scaffolding.html#responsive">Bootstrap documentation</a>
 	 */
 	boolean hasResponsiveDesign();

--- a/src/main/java/com/github/gwtbootstrap/client/ui/resources/ResourceInjector.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/resources/ResourceInjector.java
@@ -28,35 +28,35 @@ import com.google.gwt.resources.client.TextResource;
 /**
  * Utility class to inject our resources into modules page. Use it to inject
  * JavaScript and CSS files.
- * 
+ *
  * @since 2.0.4.0
- * 
+ *
  * @author Carlos Alexandro Becker
  */
 public class ResourceInjector {
 
     private static final Configurator ADAPTER = GWT.create(Configurator.class);
-    
+
     private static final InternalResourceInjector INJECTOR = GWT.create(InternalResourceInjector.class);
 
     private static HeadElement head;
 
     /**
-     * Injects the required CSS styles and JavaScript files into the document header.
+     * Injects the required CSS files into the document header.
      * <pre>
      * It's for NoStyle Module.
      * </pre>
      */
     public static void configureWithCssFile() {
-        
+
         injectResourceCssAsFile("bootstrap.min.css");
         injectResourceCssAsFile("gwt-bootstrap.css");
         injectResourceCssAsFile("font-awesome.min.css");
 
         configure();
-        
+
     }
-    
+
     /**
      * Injects the required CSS styles and JavaScript files into the document
      * header.
@@ -65,10 +65,13 @@ public class ResourceInjector {
         INJECTOR.preConfigure();
 
         Resources res = ADAPTER.getResources();
-        if(isNotLoadedJquery()) 
+        if(isNotLoadedJquery())
             injectJs(res.jquery());
 
         injectJs(res.bootstrapJs());
+        injectCss(res.bootstrapCss());
+        injectCss(res.gwtBootstrapCss());
+        injectCss(res.fontAwesomeCss());
 
         if (ADAPTER.hasResponsiveDesign())
             activateResponsiveDesign(res);


### PR DESCRIPTION
removing stylesheet tags and adding injectCss calls to configure().

Custom css files can live anywhere now, including in a Maven
src/main/resources tree (instead of the src/main/java tree).
Updated Configurator documentation to illustrate.

Carlos, your blog post at http://carlosbecker.com/posts/using-a-custom-bootstrap-theme-in-gwt-bootstrap/  is currently not working at all. This fixes it. There is also no need for a forced directory structure (css files should not live in /src/main/java) so I documented that as well.
