### PR TITLE
Release previous not visible page buttons

### DIFF
--- a/src/main/java/com/github/gwtbootstrap/client/ui/NumberedPager.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/NumberedPager.java
@@ -276,6 +276,11 @@ public class NumberedPager extends AbstractPager implements HasStyle, IsResponsi
             for (int i = firstVisibleIndex; i < lastVisibleIndex; i++) {
                 pagination.getWidget(i).setVisible(true);
             }
+        } else {
+            // Just in case there were any not visible items previously
+            for (int i = 1; i < pagination.getWidgetCount() - 1; i++) {
+                pagination.getWidget(i).setVisible(true);
+            }        	
         }
 
         // Set all numbered buttons as enabled


### PR DESCRIPTION
When all pages are visible (max visible pages < total pages), release any possible not visible page button from a previous rendering. I found this missing case.
