### PR TITLE
Fix typeahead matcher so it works with spaces

### DIFF
--- a/src/main/java/com/github/gwtbootstrap/client/ui/Typeahead.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/Typeahead.java
@@ -82,7 +82,7 @@ public class Typeahead extends MarkupWidget {
         return new MatcherCallback() {
             @Override
             public boolean compareQueryToItem(String query, String item) {
-                return item.toLowerCase().contains(query.toLowerCase());
+                return item.toLowerCase().replaceAll("</?strong>", "").contains(query.toLowerCase());
             }
         };
     }


### PR DESCRIPTION
The default matcher breaks (i.e. no suggestions are shown) if user enters text with spaces because of the HTML-markup inserted in the item text. I'm not sure the matcher should get the highlighted version of the item so I made this workaround. Probably, there could be a better fix.
