### PR TITLE
Fix typeahead matcher so it works with spaces

### DIFF
--- a/src/main/java/com/github/gwtbootstrap/client/ui/Typeahead.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/Typeahead.java
@@ -229,7 +229,7 @@ public class Typeahead extends MarkupWidget {
     }
 
     private boolean selectionMatcher(String query, String item) {
-        return this.matcherCallback.compareQueryToItem(query, item);
+        return this.matcherCallback.compareQueryToItem(query, item.replaceAll("</?strong>", ""));
     }
     
     //@formatter:off


### PR DESCRIPTION
Moved the workaround to the private method so it doesn't mess with the settable matcher callback.
