### PR TITLE
Unescape HTML entities and remove tags in typeahead

### DIFF
--- a/src/main/java/com/github/gwtbootstrap/client/ui/Typeahead.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/Typeahead.java
@@ -7,6 +7,7 @@ import com.google.gwt.core.client.JsArrayString;
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.core.client.Scheduler.ScheduledCommand;
 import com.google.gwt.user.client.Element;
+import com.google.gwt.user.client.ui.HTML;
 import com.google.gwt.user.client.ui.MultiWordSuggestOracle;
 import com.google.gwt.user.client.ui.SuggestOracle;
 import com.google.gwt.user.client.ui.SuggestOracle.Callback;
@@ -40,6 +41,7 @@ public class Typeahead extends MarkupWidget {
     private UpdaterCallback updaterCallback;
     private HighlighterCallback highlighterCallback;
     private MatcherCallback matcherCallback;
+    private HTML entityUnescaper = new HTML();
 
     /**
      * Constructor for {@link Typeahead}. Creates a {@link MultiWordSuggestOracle} to use with this
@@ -229,7 +231,8 @@ public class Typeahead extends MarkupWidget {
     }
 
     private boolean selectionMatcher(String query, String item) {
-        return this.matcherCallback.compareQueryToItem(query, item.replaceAll("</?strong>", ""));
+        entityUnescaper.setHTML(item);
+        return this.matcherCallback.compareQueryToItem(query, entityUnescaper.getText());
     }
     
     //@formatter:off


### PR DESCRIPTION
This commit replaces my previous workaround. I've discovered that the matcher breaks on HTML entities like &quot; if the matched text contains quotes. This fix should unescape HTML entities and remove tags leaving only the plain text to compare with the query.
