### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/src/main/java/com/github/gwtbootstrap/client/ui/base/ResponsiveHelper.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/base/ResponsiveHelper.java
@@ -28,8 +28,9 @@ import com.github.gwtbootstrap.client.ui.constants.ResponsiveStyle;
  * @see Device
  * @author ohashi keisuke
  */
-public class ResponsiveHelper {
+public final class ResponsiveHelper {
 
+	private ResponsiveHelper() { }
 	/**
 	 * Sets the kind of device, this widget is shown on.
 	 * 

--- a/src/main/java/com/github/gwtbootstrap/client/ui/base/SearchQueryStyleHelper.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/base/SearchQueryStyleHelper.java
@@ -26,8 +26,9 @@ import com.google.gwt.user.client.ui.Widget;
  * @since 2.0.4.0
  * @author ohashi keisuke
  */
-public class SearchQueryStyleHelper {
+public final class SearchQueryStyleHelper {
 
+	private SearchQueryStyleHelper() { }
 	/**
 	 * Set search-query style to the element.
 	 * @param widget applied style widget

--- a/src/main/java/com/github/gwtbootstrap/client/ui/base/SizeHelper.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/base/SizeHelper.java
@@ -31,11 +31,13 @@ import com.google.gwt.user.client.ui.UIObject;
  * @author ohashi keisuke
  * 
  */
-public class SizeHelper {
+public final class SizeHelper {
 
 	private static List<SizeSpan> SIZE_LIST;
 	
 	private static final ColumnSizeConfigurator CONFIGURATOR = GWT.create(ColumnSizeConfigurator.class);
+
+	private SizeHelper(){ }
 
 	// create SIZE_LIST
 	static {

--- a/src/main/java/com/github/gwtbootstrap/client/ui/base/StyleHelper.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/base/StyleHelper.java
@@ -28,8 +28,9 @@ import com.google.gwt.user.client.ui.UIObject;
  * @author ohashi keisuke
  * @author Carlos A Becker
  */
-public class StyleHelper {
+public final class StyleHelper {
 
+	private StyleHelper(){ }
 	/**
 	 * Adds the provided style to the widget.
 	 *

--- a/src/main/java/com/github/gwtbootstrap/client/ui/resources/ResourceInjector.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/resources/ResourceInjector.java
@@ -33,13 +33,17 @@ import com.google.gwt.resources.client.TextResource;
  * 
  * @author Carlos Alexandro Becker
  */
-public class ResourceInjector {
+public final class ResourceInjector {
 
     private static final Configurator ADAPTER = GWT.create(Configurator.class);
     
     private static final InternalResourceInjector INJECTOR = GWT.create(InternalResourceInjector.class);
 
     private static HeadElement head;
+
+	private ResourceInjector(){
+
+	}
 
     /**
      * Injects the required CSS styles and JavaScript files into the document header.

--- a/src/main/java/com/github/gwtbootstrap/datepicker/client/ui/resources/DatepickerResourceInjector.java
+++ b/src/main/java/com/github/gwtbootstrap/datepicker/client/ui/resources/DatepickerResourceInjector.java
@@ -27,8 +27,11 @@ import com.google.gwt.resources.client.TextResource;
  * @author Carlos Alexandro Becker
  * @since 2.0.4.0
  */
-public class DatepickerResourceInjector {
+public final class DatepickerResourceInjector {
 
+	private DatepickerResourceInjector(){
+
+	}
     /**
      * Injects the required CSS styles and JavaScript files into the document header.
      * <pre>

--- a/src/main/java/com/github/gwtbootstrap/datepicker/client/ui/util/LocaleUtil.java
+++ b/src/main/java/com/github/gwtbootstrap/datepicker/client/ui/util/LocaleUtil.java
@@ -28,13 +28,17 @@ import com.google.gwt.resources.client.TextResource;
  * @author Carlos A Becker
  * @since 2.0.4.0
  */
-public class LocaleUtil {
+public final class LocaleUtil {
 
     private static String locale = null;
     private static String LANGUAGE = null;
 
     private static List<String> loaded = new ArrayList<String>();
-    
+
+	private LocaleUtil(){
+
+	}
+	
     public static String getLanguage() {
         if (LANGUAGE == null) {
             setupLocale();

--- a/src/main/java/com/github/gwtbootstrap/datetimepicker/client/ui/resources/DatetimepickerResourceInjector.java
+++ b/src/main/java/com/github/gwtbootstrap/datetimepicker/client/ui/resources/DatetimepickerResourceInjector.java
@@ -28,9 +28,12 @@ import com.google.gwt.resources.client.TextResource;
  * @author Alain Penders
  * @since 2.1.1.0
  */
-public class DatetimepickerResourceInjector
+public final class DatetimepickerResourceInjector
 {
 
+	private DatetimepickerResourceInjector(){
+
+	}
     /**
      * Injects the required CSS styles and JavaScript files into the document header.
      * <pre>

--- a/src/main/java/com/github/gwtbootstrap/datetimepicker/client/ui/util/LocaleUtil.java
+++ b/src/main/java/com/github/gwtbootstrap/datetimepicker/client/ui/util/LocaleUtil.java
@@ -29,13 +29,16 @@ import com.google.gwt.resources.client.TextResource;
  * @author Alain Penders
  * @since 2.1.1.0
  */
-public class LocaleUtil {
+public final class LocaleUtil {
 
 	private static String locale = null;
 	private static String LANGUAGE = null;
 
 	private static List<String> loaded = new ArrayList<String>();
 
+	private LocaleUtil(){
+
+	}
 
 	public static String getLanguage() {
 		if (LANGUAGE == null) {

--- a/src/main/java/com/github/gwtbootstrap/timepicker/client/ui/resources/TimepickerResourceInjector.java
+++ b/src/main/java/com/github/gwtbootstrap/timepicker/client/ui/resources/TimepickerResourceInjector.java
@@ -12,8 +12,11 @@ import com.google.gwt.resources.client.TextResource;
  * @author Joshua Godi
  * @since 2.3.2.0
  */
-public class TimepickerResourceInjector {
+public final class TimepickerResourceInjector {
 
+	private TimepickerResourceInjector(){
+
+	}
     /**
      * Injects the required CSS styles and JavaScript files into the document header.
      * <pre>


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - Utility classes should not have public constructors
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1118
Please let me know if you have any questions.
M-Ezzat