### PR TITLE
squid:S2131 - Primitives-should-not-be-boxed-just-for-String-conversion

### DIFF
--- a/src/main/java/com/github/gwtbootstrap/client/ui/CheckBox.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/CheckBox.java
@@ -327,7 +327,7 @@ public class CheckBox extends ButtonBase implements HasName, HasValue<Boolean>, 
 
 	@Override
 	public void setAccessKey(char key) {
-		inputElem.setAccessKey("" + key);
+		inputElem.setAccessKey(Character.toString(key));
 	}
 
 	/**

--- a/src/main/java/com/github/gwtbootstrap/client/ui/base/IconAnchor.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/base/IconAnchor.java
@@ -274,7 +274,7 @@ public class IconAnchor extends ComplexWidget implements HasText, HasIcon, HasHr
 
     @Override
     public void setAccessKey(char key) {
-        DOM.setElementProperty(getElement(), "accessKey", "" + key);
+    	DOM.setElementProperty(getElement(), "accessKey", Character.toString(key));
     }
 
     @Override

--- a/src/main/java/com/github/gwtbootstrap/datepicker/client/ui/base/DateBoxBase.java
+++ b/src/main/java/com/github/gwtbootstrap/datepicker/client/ui/base/DateBoxBase.java
@@ -356,7 +356,7 @@ public class DateBoxBase extends Widget implements HasValue<Date>,HasEnabled, Ha
      */
     @Override
     public void setWeekStart(int start) {
-        getElement().setAttribute("data-date-weekstart", start + "");
+        getElement().setAttribute("data-date-weekstart", Integer.toString(start));
     }
 
     /**

--- a/src/main/java/com/github/gwtbootstrap/datetimepicker/client/ui/base/DateTimeBoxBase.java
+++ b/src/main/java/com/github/gwtbootstrap/datetimepicker/client/ui/base/DateTimeBoxBase.java
@@ -389,7 +389,7 @@ public class DateTimeBoxBase
      */
     @Override
     public void setWeekStart(int start) {
-        getElement().setAttribute("data-date-weekstart", start + "");
+        getElement().setAttribute("data-date-weekstart", Integer.toString(start));
     }
 
     /**
@@ -714,11 +714,13 @@ public class DateTimeBoxBase
             token = 'm';
         }
 
-        String out = "";
-        for(int i=0; i<count; i++)
-            out += token;
+        final StringBuilder out = new StringBuilder();
+        for(int i=0; i<count; i++) 
+        {
+            out.append(Character.toString(token));
+        }
 
-        return out;
+        return out.toString();
 
         // TODO: Support PHP format so we can do more complex formatting
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2131 - Primitives-should-not-be-boxed-just-for-String-conversion
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2131
Please let me know if you have any questions.
M-Ezzat