### PR TITLE
squid:S1213 - The members of an interface declaration or class should…

### DIFF
--- a/src/demo/java/com/github/gwtbootstrap/demo/client/BootstrapUiBinderDemo.java
+++ b/src/demo/java/com/github/gwtbootstrap/demo/client/BootstrapUiBinderDemo.java
@@ -31,6 +31,18 @@ import com.google.gwt.user.client.ui.Widget;
 
 public class BootstrapUiBinderDemo extends Composite implements HasText {
 
+	@UiField
+	Button button;
+
+	@UiField
+	Modal modal;
+
+	@UiField
+	Button modalBtn;
+
+	@UiField
+	SplitDropdownButton splitDropdownButton;
+
 	private static BootstrapUiBinderDemoUiBinder uiBinder = GWT
 			.create(BootstrapUiBinderDemoUiBinder.class);
 
@@ -48,19 +60,7 @@ public class BootstrapUiBinderDemo extends Composite implements HasText {
 			}
 		});
 	}
-
-	@UiField
-	Button button;
-
-	@UiField
-	Modal modal;
-
-	@UiField
-	Button modalBtn;
-
-	@UiField
-	SplitDropdownButton splitDropdownButton;
-
+	
 	public BootstrapUiBinderDemo(String firstName) {
 
 		initWidget(uiBinder.createAndBindUi(this));

--- a/src/main/java/com/github/gwtbootstrap/client/ui/AlertBlock.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/AlertBlock.java
@@ -45,6 +45,28 @@ public class AlertBlock extends AlertBase {
 	private final Heading heading = new Heading(4);
 
 	/**
+	 * Initializes the widget with an optional close icon.
+	 *
+	 * @param hasClose
+	 *            whether the Alert should have a close icon.
+	 */
+	public AlertBlock(boolean hasClose) {
+		super("", hasClose);
+		setUp();
+	}
+
+	/**
+	 * Creates an Alert with a close icon and the given style.
+	 *
+	 * @param type
+	 *            of the Alert
+	 */
+	public AlertBlock(AlertType type) {
+		super(type);
+		setUp();
+	}
+
+	/**
 	 * Creates an empty widget with a close icon.
 	 */
 	public AlertBlock() {
@@ -61,29 +83,7 @@ public class AlertBlock extends AlertBase {
 		heading.setStyleName(Constants.ALERT_HEADING);
 		getHeadingContainer().add(heading);
 	}
-
-	/**
-	 * Initializes the widget with an optional close icon.
-	 * 
-	 * @param hasClose
-	 *            whether the Alert should have a close icon.
-	 */
-	public AlertBlock(boolean hasClose) {
-		super("", hasClose);
-		setUp();
-	}
-
-	/**
-	 * Creates an Alert with a close icon and the given style.
-	 * 
-	 * @param type
-	 *            of the Alert
-	 */
-	public AlertBlock(AlertType type) {
-		super(type);
-		setUp();
-	}
-
+	
 	/**
 	 * {@inheritDoc}
 	 */

--- a/src/main/java/com/github/gwtbootstrap/client/ui/BigDecimalBox.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/BigDecimalBox.java
@@ -28,6 +28,8 @@ public class BigDecimalBox extends ValueBoxBase<BigDecimal> {
 
         private static BigDecimalParser INSTANCE;
 
+        protected BigDecimalParser() {}
+        
         /**
          * @return the instance of the no-op renderer
          */
@@ -37,8 +39,6 @@ public class BigDecimalBox extends ValueBoxBase<BigDecimal> {
             }
             return INSTANCE;
         }
-
-        protected BigDecimalParser() {}
 
         public BigDecimal parse(CharSequence object) throws ParseException {
             if (object == null || "".equals(object.toString())) {
@@ -56,6 +56,8 @@ public class BigDecimalBox extends ValueBoxBase<BigDecimal> {
     static class BigDecimalRenderer extends AbstractRenderer<BigDecimal> {
         private static BigDecimalRenderer INSTANCE;
 
+        protected BigDecimalRenderer() {}
+
         /**
          * @return the instance
          */
@@ -65,9 +67,7 @@ public class BigDecimalBox extends ValueBoxBase<BigDecimal> {
             }
             return INSTANCE;
         }
-
-        protected BigDecimalRenderer() {}
-
+        
         public String render(BigDecimal object) {
             if (object == null) {
                 return "";

--- a/src/main/java/com/github/gwtbootstrap/client/ui/CellTable.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/CellTable.java
@@ -65,6 +65,42 @@ public class CellTable<T> extends
 
     private static Resources DEFAULT_RESOURCES = null;
 
+    public CellTable() {
+        this(DEFAULT_PAGESIZE);
+    }
+
+    public CellTable(int pageSize, Resources resources,
+                     ProvidesKey<T> keyProvider, Widget loadingIndicator) {
+        super(pageSize, resources, keyProvider, loadingIndicator);
+        setStyleName("table");
+    }
+
+    public CellTable(int pageSize,
+                     Resources resources,
+                     ProvidesKey<T> keyProvider) {
+        this(pageSize, resources, keyProvider, createDefaultLoadingIndicator(getDefaultResources()));
+    }
+
+    public CellTable(int pageSize, Resources resources) {
+        this(pageSize, resources , null);
+    }
+
+    public CellTable(int pageSize, ProvidesKey<T> keyProvider) {
+        this(pageSize, keyProvider, createDefaultLoadingIndicator(getDefaultResources()));
+    }
+
+    public CellTable(int pageSize, ProvidesKey<T> keyProvider, Widget loadingIndicator) {
+        this(pageSize, getDefaultResources(), keyProvider, loadingIndicator);
+    }
+
+    public CellTable(int pageSize) {
+        this(pageSize, getDefaultResources());
+    }
+
+    public CellTable(ProvidesKey<T> keyProvider) {
+        this(DEFAULT_PAGESIZE, keyProvider);
+    }
+    
     private static Resources getDefaultResources() {
         if (DEFAULT_RESOURCES == null) {
             DEFAULT_RESOURCES = GWT.create(Resources.class);
@@ -98,42 +134,6 @@ public class CellTable<T> extends
     public interface SelectableStyle extends Style {
 
         String DEFAULT_CSS = "com/github/gwtbootstrap/client/ui/GwtBootstrapCellTableSelectable.css";
-    }
-
-    public CellTable() {
-        this(DEFAULT_PAGESIZE);
-    }
-
-    public CellTable(int pageSize, Resources resources,
-            ProvidesKey<T> keyProvider, Widget loadingIndicator) {
-        super(pageSize, resources, keyProvider, loadingIndicator);
-        setStyleName("table");
-    }
-
-    public CellTable(int pageSize,
-            Resources resources,
-            ProvidesKey<T> keyProvider) {
-        this(pageSize, resources, keyProvider, createDefaultLoadingIndicator(getDefaultResources()));
-    }
-
-    public CellTable(int pageSize, Resources resources) {
-        this(pageSize, resources , null);
-    }
-
-    public CellTable(int pageSize, ProvidesKey<T> keyProvider) {
-        this(pageSize, keyProvider, createDefaultLoadingIndicator(getDefaultResources()));
-    }
-
-    public CellTable(int pageSize, ProvidesKey<T> keyProvider, Widget loadingIndicator) {
-        this(pageSize, getDefaultResources(), keyProvider, loadingIndicator);
-    }
-
-    public CellTable(int pageSize) {
-        this(pageSize, getDefaultResources());
-    }
-
-    public CellTable(ProvidesKey<T> keyProvider) {
-        this(DEFAULT_PAGESIZE, keyProvider);
     }
 
     public void setStriped(boolean striped) {

--- a/src/main/java/com/github/gwtbootstrap/client/ui/DataGrid.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/DataGrid.java
@@ -37,7 +37,76 @@ import com.google.gwt.view.client.ProvidesKey;
  */
 public class DataGrid<T> extends
         com.google.gwt.user.cellview.client.DataGrid<T> implements HasStyle, IsResponsive {
-    
+    private static final int DEFAULT_PAGESIZE = 50;
+    private static Resources DEFAULT_RESOURCES;
+
+    /**
+     * Constructs a table with a default page size of 50.
+     */
+    public DataGrid() {
+        this(DEFAULT_PAGESIZE);
+    }
+
+    /**
+     * Constructs a table with the given page size.
+     *
+     * @param pageSize the page size
+     */
+    public DataGrid(final int pageSize) {
+        this(pageSize, getDefaultResources());
+    }
+
+    /**
+     * Constructs a table with the given page size and the given
+     * {@link ProvidesKey key provider}.
+     *
+     * @param pageSize the page size
+     * @param keyProvider an instance of ProvidesKey<T>, or null if the record
+     *          object should act as its own key
+     */
+    public DataGrid(int pageSize, ProvidesKey<T> keyProvider) {
+        this(pageSize, getDefaultResources(), keyProvider);
+    }
+
+    /**
+     * Constructs a table with the given page size with the specified
+     * {@link Resources}.
+     *
+     * @param pageSize the page size
+     * @param resources the resources to use for this widget
+     */
+    public DataGrid(int pageSize, Resources resources) {
+        this(pageSize, resources, null);
+    }
+
+    /**
+     * Constructs a table with the given page size, the specified
+     * {@link Resources}, and the given key provider.
+     *
+     * @param pageSize the page size
+     * @param resources the resources to use for this widget
+     * @param keyProvider an instance of ProvidesKey<T>, or null if the record
+     *          object should act as its own key
+     */
+    public DataGrid(int pageSize, Resources resources, ProvidesKey<T> keyProvider) {
+        this(pageSize, resources, keyProvider, createDefaultLoadingIndicator(resources));
+    }
+
+    /**
+     * Constructs a table with the given page size, the specified
+     * {@link Resources}, and the given key provider.
+     *
+     * @param pageSize the page size
+     * @param resources the resources to use for this widget
+     * @param keyProvider an instance of ProvidesKey<T>, or null if the record
+     *          object should act as its own key
+     * @param loadingIndicator the widget to use as a loading indicator, or null
+     *          to disable
+     */
+    public DataGrid(int pageSize, Resources resources, ProvidesKey<T> keyProvider,
+                    Widget loadingIndicator) {
+        super(pageSize, resources, keyProvider, loadingIndicator);
+    }
     
     /**
      * Basic GWT-Bootstrap style Table Resource.
@@ -79,9 +148,6 @@ public class DataGrid<T> extends
         String DEFAULT_CSS = "com/github/gwtbootstrap/client/ui/GwtBootstrapDataGridSelectable.css";
     }
     
-    private static final int DEFAULT_PAGESIZE = 50;
-    private static Resources DEFAULT_RESOURCES;
-
     /**
      * Create the default loading indicator using the loading image in the
      * specified {@link Resources}.
@@ -104,73 +170,6 @@ public class DataGrid<T> extends
         }
         return DEFAULT_RESOURCES;
       }
-    /**
-     * Constructs a table with a default page size of 50.
-     */
-    public DataGrid() {
-      this(DEFAULT_PAGESIZE);
-    }
-
-    /**
-     * Constructs a table with the given page size.
-     * 
-     * @param pageSize the page size
-     */
-    public DataGrid(final int pageSize) {
-      this(pageSize, getDefaultResources());
-    }
-
-    /**
-     * Constructs a table with the given page size and the given
-     * {@link ProvidesKey key provider}.
-     * 
-     * @param pageSize the page size
-     * @param keyProvider an instance of ProvidesKey<T>, or null if the record
-     *          object should act as its own key
-     */
-    public DataGrid(int pageSize, ProvidesKey<T> keyProvider) {
-      this(pageSize, getDefaultResources(), keyProvider);
-    }
-
-    /**
-     * Constructs a table with the given page size with the specified
-     * {@link Resources}.
-     * 
-     * @param pageSize the page size
-     * @param resources the resources to use for this widget
-     */
-    public DataGrid(int pageSize, Resources resources) {
-      this(pageSize, resources, null);
-    }
-
-    /**
-     * Constructs a table with the given page size, the specified
-     * {@link Resources}, and the given key provider.
-     * 
-     * @param pageSize the page size
-     * @param resources the resources to use for this widget
-     * @param keyProvider an instance of ProvidesKey<T>, or null if the record
-     *          object should act as its own key
-     */
-    public DataGrid(int pageSize, Resources resources, ProvidesKey<T> keyProvider) {
-      this(pageSize, resources, keyProvider, createDefaultLoadingIndicator(resources));
-    }
-
-    /**
-     * Constructs a table with the given page size, the specified
-     * {@link Resources}, and the given key provider.
-     * 
-     * @param pageSize the page size
-     * @param resources the resources to use for this widget
-     * @param keyProvider an instance of ProvidesKey<T>, or null if the record
-     *          object should act as its own key
-     * @param loadingIndicator the widget to use as a loading indicator, or null
-     *          to disable
-     */
-    public DataGrid(int pageSize, Resources resources, ProvidesKey<T> keyProvider,
-        Widget loadingIndicator) {
-        super(pageSize, resources, keyProvider, loadingIndicator);
-    }
     
     /**
      * set Striped style

--- a/src/main/java/com/github/gwtbootstrap/client/ui/DropdownContainer.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/DropdownContainer.java
@@ -62,24 +62,6 @@ public class DropdownContainer extends Dropdown {
     private boolean menuVisible;
     private HandlerManager handlerManager;
 
-    @Override
-    protected IconAnchor createTrigger() {
-        final IconAnchor trigger = super.createTrigger();
-        trigger.addDomHandler(new ClickHandler() {
-
-            @Override
-            public void onClick(ClickEvent event) {
-                if (menuVisible) {
-                    hideContainer();
-                } else {
-                    showContainer();
-                }
-            }
-        }, ClickEvent.getType());
-
-        return trigger;
-    }
-
     public DropdownContainer() {
         this("");
     }
@@ -98,6 +80,24 @@ public class DropdownContainer extends Dropdown {
         handlerManager = createHandlerManager();
     }
 
+    @Override
+    protected IconAnchor createTrigger() {
+        final IconAnchor trigger = super.createTrigger();
+        trigger.addDomHandler(new ClickHandler() {
+
+            @Override
+            public void onClick(ClickEvent event) {
+                if (menuVisible) {
+                    hideContainer();
+                } else {
+                    showContainer();
+                }
+            }
+        }, ClickEvent.getType());
+
+        return trigger;
+    }
+    
     public void showContainer() {
         menu.getElement().getStyle().setDisplay(Style.Display.BLOCK);
         menuVisible = true;

--- a/src/main/java/com/github/gwtbootstrap/client/ui/Form.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/Form.java
@@ -67,6 +67,18 @@ public class Form extends ComplexWidget implements FormPanelImplHost {
 		 * The event type.
 		 */
 		private static Type<SubmitCompleteHandler> TYPE;
+		
+		private final String resultHtml;
+
+		/**
+		 * Create a submit complete event.
+		 *
+		 * @param resultsHtml
+		 *            the results from submitting the form
+		 */
+		protected SubmitCompleteEvent(String resultsHtml) {
+			this.resultHtml = resultsHtml;
+		}
 
 		/**
 		 * Handler hook.
@@ -79,19 +91,7 @@ public class Form extends ComplexWidget implements FormPanelImplHost {
 			}
 			return TYPE;
 		}
-
-		private final String resultHtml;
-
-		/**
-		 * Create a submit complete event.
-		 * 
-		 * @param resultsHtml
-		 *            the results from submitting the form
-		 */
-		protected SubmitCompleteEvent(String resultsHtml) {
-			this.resultHtml = resultsHtml;
-		}
-
+		
 		@Override
 		public final Type<SubmitCompleteHandler> getAssociatedType() {
 			return TYPE;
@@ -138,6 +138,8 @@ public class Form extends ComplexWidget implements FormPanelImplHost {
 		 * The event type.
 		 */
 		private static Type<SubmitHandler> TYPE = new Type<SubmitHandler>();
+		
+		private boolean canceled = false;
 
 		/**
 		 * Handler hook.
@@ -150,9 +152,7 @@ public class Form extends ComplexWidget implements FormPanelImplHost {
 			}
 			return TYPE;
 		}
-
-		private boolean canceled = false;
-
+		
 		/**
 		 * Cancel the form submit. Firing this will prevent a subsequent
 		 * {@link SubmitCompleteEvent} from being fired.
@@ -220,6 +220,41 @@ public class Form extends ComplexWidget implements FormPanelImplHost {
 	}
 
 	/**
+	 * This constructor may be used by subclasses to explicitly use an existing
+	 * element. This element must be a &lt;form&gt; element.
+	 *
+	 * <p>
+	 * If the createIFrame parameter is set to <code>true</code>, then the
+	 * wrapped form's target attribute will be set to a hidden iframe. If not,
+	 * the form's target will be left alone, and the FormSubmitComplete event
+	 * will not be fired.
+	 * </p>
+	 *
+	 * @param element
+	 *            the element to be used
+	 * @param createIFrame
+	 *            <code>true</code> to create an &lt;iframe&gt; element that
+	 *            will be targeted by this form
+	 */
+	protected Form(Element element,
+				   boolean createIFrame) {
+		super(element.getTagName());
+		FormElement.as(element);
+
+		if (createIFrame) {
+			assert ((getTarget() == null) || (getTarget().trim().length() == 0)) : "Cannot create target iframe if the form's target is already set.";
+
+			// We use the module name as part of the unique ID to ensure that
+			// ids are
+			// unique across modules.
+			frameName = "BSFormPanel_" + GWT.getModuleName() + "_" + (++formId);
+			setTarget(frameName);
+
+			sinkEvents(Event.ONLOAD);
+		}
+	}
+
+	/**
 	 * Adds a {@link SubmitCompleteEvent} handler.
 	 * 
 	 * @param handler
@@ -270,42 +305,7 @@ public class Form extends ComplexWidget implements FormPanelImplHost {
 	public String getMethod() {
 		return getFormElement().getMethod();
 	}
-
-	/**
-	 * This constructor may be used by subclasses to explicitly use an existing
-	 * element. This element must be a &lt;form&gt; element.
-	 * 
-	 * <p>
-	 * If the createIFrame parameter is set to <code>true</code>, then the
-	 * wrapped form's target attribute will be set to a hidden iframe. If not,
-	 * the form's target will be left alone, and the FormSubmitComplete event
-	 * will not be fired.
-	 * </p>
-	 * 
-	 * @param element
-	 *            the element to be used
-	 * @param createIFrame
-	 *            <code>true</code> to create an &lt;iframe&gt; element that
-	 *            will be targeted by this form
-	 */
-	protected Form(Element element,
-		boolean createIFrame) {
-		super(element.getTagName());
-		FormElement.as(element);
-
-		if (createIFrame) {
-			assert ((getTarget() == null) || (getTarget().trim().length() == 0)) : "Cannot create target iframe if the form's target is already set.";
-
-			// We use the module name as part of the unique ID to ensure that
-			// ids are
-			// unique across modules.
-			frameName = "BSFormPanel_" + GWT.getModuleName() + "_" + (++formId);
-			setTarget(frameName);
-
-			sinkEvents(Event.ONLOAD);
-		}
-	}
-
+	
 	public String getTarget() {
 		return getFormElement().getTarget();
 	}

--- a/src/main/java/com/github/gwtbootstrap/client/ui/PasswordTextBox.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/PasswordTextBox.java
@@ -32,6 +32,26 @@ import com.google.gwt.user.client.ui.Widget;
 public class PasswordTextBox extends TextBox {
 
 	/**
+	 * Creates an empty password text box.
+	 */
+	public PasswordTextBox() {
+		super(Document.get().createPasswordInputElement(), "gwt-PasswordTextBox");
+	}
+
+	/**
+	 * This constructor may be used by subclasses to explicitly use an existing
+	 * element. This element must be an &lt;input&gt; element whose type is
+	 * 'password'.
+	 *
+	 * @param element
+	 *            the element to be used
+	 */
+	protected PasswordTextBox(Element element) {
+		super(element, null);
+		assert InputElement.as(element).getType().equalsIgnoreCase("password");
+	}
+
+	/**
 	 * Creates a PasswordTextBox widget that wraps an existing &lt;input
 	 * type='password'&gt; element.
 	 * 
@@ -54,24 +74,5 @@ public class PasswordTextBox extends TextBox {
 
 		return textBox;
 	}
-
-	/**
-	 * Creates an empty password text box.
-	 */
-	public PasswordTextBox() {
-		super(Document.get().createPasswordInputElement(), "gwt-PasswordTextBox");
-	}
-
-	/**
-	 * This constructor may be used by subclasses to explicitly use an existing
-	 * element. This element must be an &lt;input&gt; element whose type is
-	 * 'password'.
-	 * 
-	 * @param element
-	 *            the element to be used
-	 */
-	protected PasswordTextBox(Element element) {
-		super(element, null);
-		assert InputElement.as(element).getType().equalsIgnoreCase("password");
-	}
+	
 }

--- a/src/main/java/com/github/gwtbootstrap/client/ui/SimplePager.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/SimplePager.java
@@ -94,15 +94,8 @@ public class SimplePager extends AbstractPager {
 
     private static final int DEFAULT_FAST_FORWARD_ROWS = 100;
     private static Resources DEFAULT_RESOURCES;
-
-    private static Resources getDefaultResources() {
-        if (DEFAULT_RESOURCES == null) {
-            DEFAULT_RESOURCES = GWT.create(Resources.class);
-        }
-        return DEFAULT_RESOURCES;
-    }
-
     private final int tooltipDelay = 1000;
+    
     private final Placement tooltipPlacement = Placement.BOTTOM;
 
     private final Button fastForward;
@@ -149,12 +142,13 @@ public class SimplePager extends AbstractPager {
      * @param location
      *            the location of the text relative to the buttons
      */
+
     @UiConstructor
     // Hack for Google I/O demo
     public SimplePager(TextLocation location) {
         this(location, getDefaultResources(), true, DEFAULT_FAST_FORWARD_ROWS, false);
     }
-
+    
     /**
      * Construct a {@link SimplePager} with the default resources, fast forward
      * rows and default image button names.
@@ -357,6 +351,13 @@ public class SimplePager extends AbstractPager {
         this(location, resources, showFastForwardButton, fastForwardRows, showLastPageButton, GWT.<ImageButtonsConstants> create(ImageButtonsConstants.class));
     }
 
+    private static Resources getDefaultResources() {
+        if (DEFAULT_RESOURCES == null) {
+            DEFAULT_RESOURCES = GWT.create(Resources.class);
+        }
+        return DEFAULT_RESOURCES;
+    }
+    
     @Override
     public void firstPage() {
         super.firstPage();

--- a/src/main/java/com/github/gwtbootstrap/client/ui/SubmitButton.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/SubmitButton.java
@@ -53,11 +53,7 @@ public class SubmitButton extends FocusWidget implements HasType<ButtonType>, Ha
 		super(Document.get().createSubmitInputElement());
 		setStyleName(Constants.BTN);
 	}
-
-	private InputElement asInputElement() {
-		return getElement().cast();
-	}
-
+	
 	/**
 	 * This constructor may be used by subclasses to explicitly use an existing
 	 * element. This element must be a &lt;input type="submit"&gt; element.
@@ -116,6 +112,10 @@ public class SubmitButton extends FocusWidget implements HasType<ButtonType>, Ha
 	public SubmitButton(String text) {
 		this();
 		setValue(text);
+	}
+
+	private InputElement asInputElement() {
+		return getElement().cast();
 	}
 
 	/**

--- a/src/main/java/com/github/gwtbootstrap/client/ui/TextArea.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/TextArea.java
@@ -32,6 +32,26 @@ import com.google.gwt.user.client.ui.Widget;
 public class TextArea extends TextBoxBase {
 
 	/**
+	 * Creates an empty text area.
+	 */
+	public TextArea() {
+		super(Document.get().createTextAreaElement());
+		setStyleName("gwt-TextArea");
+	}
+
+	/**
+	 * This constructor may be used by subclasses to explicitly use an existing
+	 * element. This element must be a &lt;textarea&gt; element.
+	 *
+	 * @param element
+	 *            the element to be used
+	 */
+	protected TextArea(Element element) {
+		super(element.<Element> cast());
+		TextAreaElement.as(element);
+	}
+
+	/**
 	 * Creates a TextArea widget that wraps an existing &lt;textarea&gt;
 	 * element.
 	 * 
@@ -54,27 +74,7 @@ public class TextArea extends TextBoxBase {
 
 		return textArea;
 	}
-
-	/**
-	 * Creates an empty text area.
-	 */
-	public TextArea() {
-		super(Document.get().createTextAreaElement());
-		setStyleName("gwt-TextArea");
-	}
-
-	/**
-	 * This constructor may be used by subclasses to explicitly use an existing
-	 * element. This element must be a &lt;textarea&gt; element.
-	 * 
-	 * @param element
-	 *            the element to be used
-	 */
-	protected TextArea(Element element) {
-		super(element.<Element> cast());
-		TextAreaElement.as(element);
-	}
-
+	
 	/**
 	 * Gets the requested width of the text box (this is not an exact value, as
 	 * not all characters are created equal).

--- a/src/main/java/com/github/gwtbootstrap/client/ui/TextBox.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/TextBox.java
@@ -34,6 +34,33 @@ import com.google.gwt.user.client.ui.Widget;
 public class TextBox extends TextBoxBase {
 
 	/**
+	 * Creates an empty text box.
+	 */
+	public TextBox() {
+		this(Document.get().createTextInputElement(), "gwt-TextBox");
+	}
+
+	/**
+	 * This constructor may be used by subclasses to explicitly use an existing
+	 * element. This element must be an &lt;input&gt; element whose type is
+	 * 'text'.
+	 *
+	 * @param element
+	 *            the element to be used
+	 */
+	protected TextBox(Element element) {
+		super(element);
+		assert InputElement.as(element).getType().equalsIgnoreCase("text");
+	}
+
+	TextBox(Element element,
+			String styleName) {
+		super(element);
+		if (styleName != null) {
+			setStyleName(styleName);
+		}
+	}
+	/**
 	 * Creates a TextBox widget that wraps an existing &lt;input type='text'&gt;
 	 * element.
 	 * 
@@ -55,34 +82,6 @@ public class TextBox extends TextBoxBase {
 		RootPanel.detachOnWindowClose(textBox);
 
 		return textBox;
-	}
-
-	/**
-	 * Creates an empty text box.
-	 */
-	public TextBox() {
-		this(Document.get().createTextInputElement(), "gwt-TextBox");
-	}
-
-	/**
-	 * This constructor may be used by subclasses to explicitly use an existing
-	 * element. This element must be an &lt;input&gt; element whose type is
-	 * 'text'.
-	 * 
-	 * @param element
-	 *            the element to be used
-	 */
-	protected TextBox(Element element) {
-		super(element);
-		assert InputElement.as(element).getType().equalsIgnoreCase("text");
-	}
-
-	TextBox(Element element,
-		String styleName) {
-		super(element);
-		if (styleName != null) {
-			setStyleName(styleName);
-		}
 	}
 
 	/**

--- a/src/main/java/com/github/gwtbootstrap/client/ui/ValueBox.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/ValueBox.java
@@ -39,6 +39,26 @@ import com.google.gwt.user.client.ui.Widget;
 public class ValueBox<T> extends ValueBoxBase<T> {
 
 	/**
+	 * This constructor may be used by subclasses to explicitly use an existing
+	 * element. This element must be an &lt;input&gt; element whose type is
+	 * 'text'.
+	 *
+	 * @param element
+	 *            the element to be used
+	 */
+	protected ValueBox(Element element,
+					   Renderer<T> renderer,
+					   Parser<T> parser) {
+		super(element, renderer, parser);
+		// BiDi input is not expected - disable direction estimation.
+		setDirectionEstimator(false);
+		if (LocaleInfo.getCurrentLocale().isRTL()) {
+			setDirection(Direction.LTR);
+		}
+		assert InputElement.as(element).getType().equalsIgnoreCase("text");
+	}
+
+	/**
 	 * Creates a ValueBox widget that wraps an existing &lt;input
 	 * type='text'&gt; element.
 	 * 
@@ -61,27 +81,7 @@ public class ValueBox<T> extends ValueBoxBase<T> {
 
 		return valueBox;
 	}
-
-	/**
-	 * This constructor may be used by subclasses to explicitly use an existing
-	 * element. This element must be an &lt;input&gt; element whose type is
-	 * 'text'.
-	 * 
-	 * @param element
-	 *            the element to be used
-	 */
-	protected ValueBox(Element element,
-		Renderer<T> renderer,
-		Parser<T> parser) {
-		super(element, renderer, parser);
-		// BiDi input is not expected - disable direction estimation.
-		setDirectionEstimator(false);
-		if (LocaleInfo.getCurrentLocale().isRTL()) {
-			setDirection(Direction.LTR);
-		}
-		assert InputElement.as(element).getType().equalsIgnoreCase("text");
-	}
-
+	
 	/**
 	 * Gets the maximum allowable length.
 	 * 

--- a/src/main/java/com/github/gwtbootstrap/client/ui/event/ClosedEvent.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/event/ClosedEvent.java
@@ -31,6 +31,14 @@ public class ClosedEvent<T> extends GwtEvent<ClosedHandler<T>> {
 
     private static final Type<ClosedHandler<?>> TYPE = new Type<ClosedHandler<?>>();
 
+    private final T target;
+    private final boolean autoClosed;
+
+    public ClosedEvent(T target, boolean autoClosed) {
+        this.target = target;
+        this.autoClosed = autoClosed;
+    }
+
     public static Type<ClosedHandler<?>> getType() {
         return TYPE;
     }
@@ -62,15 +70,7 @@ public class ClosedEvent<T> extends GwtEvent<ClosedHandler<T>> {
             source.fireEvent(event);
         }
     }
-
-    private final T target;
-    private final boolean autoClosed;
-
-    public ClosedEvent(T target, boolean autoClosed) {
-        this.target = target;
-        this.autoClosed = autoClosed;
-    }
-
+    
     // The instance knows its of type T, but the TYPE
     // field itself does not, so we have to do an unsafe cast here.
     @SuppressWarnings("unchecked")

--- a/src/main/java/com/github/gwtbootstrap/client/ui/event/HiddenEvent.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/event/HiddenEvent.java
@@ -35,11 +35,7 @@ public class HiddenEvent extends GwtEvent<HiddenHandler> {
     private static final Type<HiddenHandler> TYPE = new Type<HiddenHandler>();
     private final NativeEvent nativeEvent;
     private final boolean autoHidden;
-
-    public static Type<HiddenHandler> getType() {
-        return TYPE;
-    }
-
+    
     public HiddenEvent() {
         this(null, false);
     }
@@ -55,6 +51,10 @@ public class HiddenEvent extends GwtEvent<HiddenHandler> {
     public HiddenEvent(NativeEvent nativeEvent, boolean autoHidden) {
         this.nativeEvent = nativeEvent;
         this.autoHidden = autoHidden;
+    }
+
+    public static Type<HiddenHandler> getType() {
+        return TYPE;
     }
 
     @Override

--- a/src/main/java/com/github/gwtbootstrap/client/ui/event/HideEvent.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/event/HideEvent.java
@@ -37,10 +37,6 @@ public class HideEvent extends GwtEvent<HideHandler> {
     private final NativeEvent nativeEvent;
     private final boolean autoHidden;
 
-    public static Type<HideHandler> getType() {
-        return TYPE;
-    }
-
     public HideEvent() {
         this(null);
     }
@@ -56,6 +52,10 @@ public class HideEvent extends GwtEvent<HideHandler> {
     public HideEvent(NativeEvent nativeEvent, boolean autoHidden) {
         this.nativeEvent = nativeEvent;
         this.autoHidden = autoHidden;
+    }
+
+    public static Type<HideHandler> getType() {
+        return TYPE;
     }
 
     @Override

--- a/src/main/java/com/github/gwtbootstrap/client/ui/event/ShowEvent.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/event/ShowEvent.java
@@ -37,10 +37,6 @@ public class ShowEvent extends GwtEvent<ShowHandler> {
     private final NativeEvent nativeEvent;
     private final boolean autoShown;
 
-    public static Type<ShowHandler> getType() {
-        return TYPE;
-    }
-
     public ShowEvent() {
         this(null);
     }
@@ -58,6 +54,10 @@ public class ShowEvent extends GwtEvent<ShowHandler> {
         this.autoShown = autoShown;
     }
 
+    public static Type<ShowHandler> getType() {
+        return TYPE;
+    }
+    
     @Override
     public final Type<ShowHandler> getAssociatedType() {
         return TYPE;

--- a/src/main/java/com/github/gwtbootstrap/client/ui/event/ShownEvent.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/event/ShownEvent.java
@@ -36,11 +36,7 @@ public class ShownEvent extends GwtEvent<ShownHandler> {
     private static final Type<ShownHandler> TYPE = new Type<ShownHandler>();
     private final NativeEvent nativeEvent;
     private final boolean autoShown;
-
-    public static Type<ShownHandler> getType() {
-        return TYPE;
-    }
-
+    
     public ShownEvent() {
         this(null);
     }
@@ -56,6 +52,10 @@ public class ShownEvent extends GwtEvent<ShownHandler> {
     public ShownEvent(NativeEvent nativeEvent, boolean autoShown) {
         this.nativeEvent = nativeEvent;
         this.autoShown = autoShown;
+    }
+
+    public static Type<ShownHandler> getType() {
+        return TYPE;
     }
 
     @Override

--- a/src/main/java/com/github/gwtbootstrap/client/ui/incubator/PickList.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/incubator/PickList.java
@@ -49,6 +49,8 @@ import java.util.List;
  * @see NameValuePairImpl
  */
 public class PickList extends Composite {
+    private static PickListUiBinder ourUiBinder = GWT.create(PickListUiBinder.class);
+
     @UiField
     VerticalPanel leftPanel;
     @UiField
@@ -68,7 +70,20 @@ public class PickList extends Composite {
     Label rightPanelLabel;
     @UiField
     Label leftPanelLabel;
+    
+    public PickList() {
+        initWidget(ourUiBinder.createAndBindUi(this));
 
+        //set padding between cells to make the component look better
+        this.getElement().setAttribute("cellpadding", "1");
+        leftPanel.getElement().setAttribute("cellpadding", "1");
+        buttonPanel.getElement().setAttribute("cellpadding", "1");
+        rightPanel.getElement().setAttribute("cellpadding", "1");
+
+        setLeftListElements(new ArrayList<NameValuePair>());
+        setRightListElements(new ArrayList<NameValuePair>());
+    }
+    
     public void clearLeftList() {
         clear(leftList);
     }
@@ -190,19 +205,5 @@ public class PickList extends Composite {
 
     interface PickListUiBinder extends UiBinder<HorizontalPanel, PickList> {
     }
-
-    private static PickListUiBinder ourUiBinder = GWT.create(PickListUiBinder.class);
-
-    public PickList() {
-        initWidget(ourUiBinder.createAndBindUi(this));
-
-        //set padding between cells to make the component look better
-        this.getElement().setAttribute("cellpadding", "1");
-        leftPanel.getElement().setAttribute("cellpadding", "1");
-        buttonPanel.getElement().setAttribute("cellpadding", "1");
-        rightPanel.getElement().setAttribute("cellpadding", "1");
-
-        setLeftListElements(new ArrayList<NameValuePair>());
-        setRightListElements(new ArrayList<NameValuePair>());
-    }
+    
 }

--- a/src/showcase/java/com/github/gwtbootstrap/showcase/client/Navigation.java
+++ b/src/showcase/java/com/github/gwtbootstrap/showcase/client/Navigation.java
@@ -72,6 +72,8 @@ public class Navigation extends Composite {
     @UiField
     Button cancelButton;
 
+    @UiField Button removeTab;
+    
     private static NavigationEntriesUiBinder uiBinder = GWT.create(NavigationEntriesUiBinder.class);
 
     interface NavigationEntriesUiBinder extends UiBinder<Widget, Navigation> {
@@ -126,7 +128,6 @@ public class Navigation extends Composite {
         tabPanel.setTabPosition(e.getValue().name().toLowerCase());
     }
     
-    @UiField Button removeTab;
     @UiHandler("removeTab")
     void onClickRemoveTab(ClickEvent e) {
         if(firstTab.asTabLink().isActive()) tabPanel.remove(firstTab);

--- a/src/showcase/java/com/github/gwtbootstrap/showcase/client/NonResShowcase.java
+++ b/src/showcase/java/com/github/gwtbootstrap/showcase/client/NonResShowcase.java
@@ -40,6 +40,23 @@ import com.google.gwt.user.client.ui.Widget;
 
 public class NonResShowcase extends Composite implements EntryPoint {
 
+    @UiField
+    FlowPanel sections;
+    @UiField
+    Nav nav;
+    @UiField
+    HTMLPanel github_buttons;
+
+    private static ShowcaseUiBinder uiBinder = GWT
+            .create(ShowcaseUiBinder.class);
+
+    public NonResShowcase() {
+
+        ResourceInjector.configureWithCssFile();
+        DatepickerResourceInjector.configureWithCssFile();
+        DatetimepickerResourceInjector.configureWithCssFile();
+    }
+
     public void onModuleLoad() {
         initWidget(uiBinder.createAndBindUi(this));
         addSectionToContainer("Buttons", "buttons", new Buttons());
@@ -88,28 +105,11 @@ public class NonResShowcase extends Composite implements EntryPoint {
             }
         });
     }
-
-    @UiField
-    FlowPanel sections;
-    @UiField
-    Nav nav;
-    @UiField
-    HTMLPanel github_buttons;
-
-    private static ShowcaseUiBinder uiBinder = GWT
-            .create(ShowcaseUiBinder.class);
-
+    
     @UiTemplate("Showcase.ui.xml")
     interface ShowcaseUiBinder extends UiBinder<Widget, NonResShowcase> {
     }
-
-    public NonResShowcase() {
-
-        ResourceInjector.configureWithCssFile();
-        DatepickerResourceInjector.configureWithCssFile();
-        DatetimepickerResourceInjector.configureWithCssFile();
-    }
-
+    
     private void addSectionToContainer(String sectionName, String target,
             Widget section) {
         nav.add(new NavLink(sectionName, "#" + target));

--- a/src/showcase/java/com/github/gwtbootstrap/showcase/client/util/Person.java
+++ b/src/showcase/java/com/github/gwtbootstrap/showcase/client/util/Person.java
@@ -29,6 +29,18 @@ public class Person {
 	private Date birthDay;
 	
 	private Favorite favorite = Favorite.NONE;
+
+	public Person() {
+
+	}
+
+	public Person(Integer id, String userName,Integer age, Favorite choice, Date birthDay) {
+		this.id = id;
+		this.userName = userName;
+		this.age = age;
+		this.favorite = choice;
+		this.birthDay = birthDay;
+	}
 	
 	public Integer getId() {
 		return id;
@@ -67,18 +79,6 @@ public class Person {
 	
 	public void setFavorite(Favorite favorite) {
 		this.favorite = favorite;
-	}
-
-	public Person() {
-		
-	}
-	
-	public Person(Integer id, String userName,Integer age, Favorite choice, Date birthDay) {
-		this.id = id;
-		this.userName = userName;
-		this.age = age;
-		this.favorite = choice;
-		this.birthDay = birthDay;
 	}
 
 	public Date getBirthDay() {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1213

Please let me know if you have any questions.

M-Ezzat