### PR TITLE
squid:S1186 - Methods should not be empty

### DIFF
--- a/src/main/java/com/github/gwtbootstrap/client/ui/RadioButton.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/RadioButton.java
@@ -275,5 +275,6 @@ public class RadioButton extends CheckBox {
 	 */
 	@Override
 	protected void ensureDomEventHandlers() {
+		// Do nothing
 	}
 }

--- a/src/main/java/com/github/gwtbootstrap/client/ui/resources/internal/DefaultInternalInjector.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/resources/internal/DefaultInternalInjector.java
@@ -4,10 +4,12 @@ public class DefaultInternalInjector implements InternalResourceInjector {
 
     @Override
     public void configure() {
+        // Do nothing
     }
 
     @Override
     public void preConfigure() {
+        // Do nothing
     }
 
 }

--- a/src/main/java/com/github/gwtbootstrap/client/ui/resources/internal/LowVersionIEResourceInjector.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/resources/internal/LowVersionIEResourceInjector.java
@@ -5,6 +5,7 @@ public class LowVersionIEResourceInjector implements InternalResourceInjector {
 
     @Override
     public void configure() {
+        // Do nothing
     }
 
     @Override

--- a/src/showcase/java/com/github/gwtbootstrap/showcase/client/AsyncCodeBlock.java
+++ b/src/showcase/java/com/github/gwtbootstrap/showcase/client/AsyncCodeBlock.java
@@ -58,7 +58,7 @@ public class AsyncCodeBlock extends Composite {
 			
 			@Override
 			public void onError(Request request, Throwable exception) {
-				
+				// Do nothing
 			}
 		});
 	}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1186 - Methods should not be empty

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1186

Please let me know if you have any questions.

M-Ezzat