### PR TITLE
squid:MissingDeprecatedCheck - Deprecated elements should have both t…

### DIFF
--- a/src/main/java/com/github/gwtbootstrap/client/ui/Modal.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/Modal.java
@@ -607,6 +607,7 @@ public class Modal extends DivWidget implements HasVisibility, HasVisibleHandler
     /**
      * @deprecated modal do not support setSize method
      */
+    @Deprecated
     @Override
     public void setSize(String width, String height) {
         throw new UnsupportedOperationException("modal do not support setSize method");

--- a/src/main/java/com/github/gwtbootstrap/client/ui/Pagination.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/Pagination.java
@@ -172,7 +172,7 @@ public class Pagination extends Composite implements HasStyle, IsResponsive, Has
 
     /**
      * Use setPullRight instead.
-     *
+     * @deprecated
      * @param pullRight
      *            <code>true</code> if the widget should be aligned right.
      */

--- a/src/main/java/com/github/gwtbootstrap/client/ui/base/AddOn.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/base/AddOn.java
@@ -145,8 +145,11 @@ public class AddOn extends ComplexWidget implements HasText, HasIcon {
         icon.addStyleName(customIconStyle);
     }
 
-    @Override
+    /**
+     * @deprecated
+     */
     @Deprecated
+    @Override
     public void setIconPosition(IconPosition position) {
         throw new UnsupportedOperationException("Addon does not support this methods");
     }

--- a/src/main/java/com/github/gwtbootstrap/client/ui/base/DivWidget.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/base/DivWidget.java
@@ -62,6 +62,9 @@ public class DivWidget extends FlowPanel implements HasStyle, IsResponsive, HasI
 		setStyleName(styleName);
 	}
 
+	/**
+	 * @deprecated
+	 */
 	@Deprecated
 	public void pullRight(boolean pullRight) {
 		setPullRight(pullRight);

--- a/src/main/java/com/github/gwtbootstrap/datepicker/client/ui/DateBoxAppended.java
+++ b/src/main/java/com/github/gwtbootstrap/datepicker/client/ui/DateBoxAppended.java
@@ -168,6 +168,7 @@ public class DateBoxAppended extends AppendButton implements HasValue<Date>,
      *
      * @deprecated
      */
+    @Deprecated
     @Override
     public void setIconPosition(IconPosition position) {
         icon.setIconPosition(position);

--- a/src/main/java/com/github/gwtbootstrap/datetimepicker/client/ui/DateTimeBoxAppended.java
+++ b/src/main/java/com/github/gwtbootstrap/datetimepicker/client/ui/DateTimeBoxAppended.java
@@ -173,6 +173,7 @@ public class DateTimeBoxAppended
      *
      * @deprecated
      */
+    @Deprecated
     @Override
     public void setIconPosition(IconPosition position) {
         icon.setIconPosition(position);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:MissingDeprecatedCheck - Deprecated elements should have both the annotation and the Javadoc tag

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:MissingDeprecatedCheck

Please let me know if you have any questions.

M-Ezzat