### PR TITLE
squid:UselessParenthesesCheck, squid:SwitchLastCaseIsDefaultCheck

### DIFF
--- a/src/main/java/com/github/gwtbootstrap/client/ui/Form.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/Form.java
@@ -242,7 +242,7 @@ public class Form extends ComplexWidget implements FormPanelImplHost {
 		FormElement.as(element);
 
 		if (createIFrame) {
-			assert ((getTarget() == null) || (getTarget().trim().length() == 0)) : "Cannot create target iframe if the form's target is already set.";
+			assert (getTarget() == null || getTarget().trim().length() == 0) : "Cannot create target iframe if the form's target is already set.";
 
 			// We use the module name as part of the unique ID to ensure that
 			// ids are

--- a/src/main/java/com/github/gwtbootstrap/client/ui/RadioButton.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/RadioButton.java
@@ -239,6 +239,8 @@ public class RadioButton extends CheckBox {
 			// ...and now maybe tell them about the change
 			ValueChangeEvent.fireIfNotEqual(RadioButton.this, oldValue, getValue());
 			return;
+			default:
+				break;
 		}
 		super.onBrowserEvent(event);
 	}

--- a/src/main/java/com/github/gwtbootstrap/client/ui/base/ResponsiveHelper.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/base/ResponsiveHelper.java
@@ -62,6 +62,8 @@ public final class ResponsiveHelper {
 			case DESKTOP:
 				widget.addStyle(ResponsiveStyle.VISIBLE_DESKTOP);
 				break;
+			default:
+				break;
 		}
 	}
 
@@ -96,6 +98,8 @@ public final class ResponsiveHelper {
 				break;
 			case DESKTOP:
 				widget.addStyle(ResponsiveStyle.HIDDEN_DESKTOP);
+				break;
+			default:
 				break;
 		}
 	}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding and
squid:SwitchLastCaseIsDefaultCheck - "switch" statements should end with a "default" clause

You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:UselessParenthesesCheck
https://dev.eclipse.org/sonar/coding_rules#q=squid:SwitchLastCaseIsDefaultCheck

Please let me know if you have any questions.

M-Ezzat