### PR TITLE
squid:S1939,pmd:UseStringBufferForStringAppends,pmd:UseIndexOfChar - …

### DIFF
--- a/src/main/java/com/github/gwtbootstrap/client/ui/Bar.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/Bar.java
@@ -69,7 +69,7 @@ public class Bar extends DivWidget {
         if (width == null)
             return 0;
         else
-            return Double.valueOf(width.substring(0, width.indexOf("%")));
+            return Double.valueOf(width.substring(0, width.indexOf('%')));
     }
     
     /**

--- a/src/main/java/com/github/gwtbootstrap/datepicker/client/ui/DateBoxAppended.java
+++ b/src/main/java/com/github/gwtbootstrap/datepicker/client/ui/DateBoxAppended.java
@@ -52,7 +52,7 @@ import java.util.Date;
  * @author Carlos Alexandro Becker
  */
 public class DateBoxAppended extends AppendButton implements HasValue<Date>,
-        HasDateFormat, HasIcon, HasValueChangeHandlers<Date>, HasVisibility,
+        HasIcon, HasValueChangeHandlers<Date>, HasVisibility,
         HasChangeHandlers, HasVisibleHandlers, HasAllDatePickerHandlers,
         HasAlternateSize, IsEditor<TakesValueEditor<Date>> {
 

--- a/src/main/java/com/github/gwtbootstrap/datetimepicker/client/ui/DateTimeBoxAppended.java
+++ b/src/main/java/com/github/gwtbootstrap/datetimepicker/client/ui/DateTimeBoxAppended.java
@@ -53,11 +53,10 @@ import java.util.Date;
  * @author Alain Penders
  * @since 2.1.1.0
  */
-public class DateTimeBoxAppended
-	extends AppendButton implements HasValue<Date>,
-	                                HasDateFormat, HasIcon, HasValueChangeHandlers<Date>, HasVisibility,
-        HasChangeHandlers, HasVisibleHandlers, HasAllDateTimePickerHandlers,
-        HasAlternateSize, IsEditor<TakesValueEditor<Date>> {
+public class DateTimeBoxAppended extends AppendButton implements
+		HasValue<Date>, HasIcon, HasValueChangeHandlers<Date>, HasVisibility,
+		HasChangeHandlers, HasVisibleHandlers, HasAllDateTimePickerHandlers,
+		HasAlternateSize, IsEditor<TakesValueEditor<Date>> {
 
     /**
      * An 'adapter' to change some aspects of the behavior of datepickerbase.

--- a/src/main/java/com/github/gwtbootstrap/datetimepicker/client/ui/base/DateTimeBoxBase.java
+++ b/src/main/java/com/github/gwtbootstrap/datetimepicker/client/ui/base/DateTimeBoxBase.java
@@ -663,7 +663,7 @@ public class DateTimeBoxBase
         char current;
         char last = dpGlobalFormat.charAt(0);
         int count = 1;
-        String out = "";
+        StringBuilder out = new StringBuilder();
 
         for(int index = 1; index < dpGlobalFormat.length(); index++)
         {
@@ -675,15 +675,15 @@ public class DateTimeBoxBase
                 continue;
             }
 
-            out += processToken(last, count);
+            out.append(processToken(last, count));
 
             last = current;
             count = 1;
         }
 
-        out += processToken(last, count);
+        out.append(processToken(last, count));
 
-        return out;
+        return out.toString();
     }
 
     private String processToken(char token, int count)


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules squid:S1939 - Extensions and implementations should not be redundant
pmd:UseStringBufferForStringAppends - Use String Buffer For String Appends
pmd:UseIndexOfChar - Use Index Of Char

You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1939
https://dev.eclipse.org/sonar/coding_rules#q=pmd:UseStringBufferForStringAppends
https://dev.eclipse.org/sonar/coding_rules#q=pmd:UseIndexOfChar

Please let me know if you have any questions.

M-Ezzat