### PR TITLE
squid:S1941 - Variables should not be declared before they are relevant

### DIFF
--- a/src/main/java/com/github/gwtbootstrap/client/ui/Breadcrumbs.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/Breadcrumbs.java
@@ -241,8 +241,6 @@ public class Breadcrumbs extends UnorderedList {
             return false;
         }
         
-        boolean isLastWidget = (children.indexOf(w) == children.size() -1) || (getWidgetIndex(w) == getWidgetCount() -1);
-        
         if(getWidgetIndex(w) >= 0 && children.contains(w)) {
             children.remove(w);
             super.remove(w);
@@ -254,7 +252,8 @@ public class Breadcrumbs extends UnorderedList {
         } else {
             return false;
         }
-        
+
+        boolean isLastWidget = (children.indexOf(w) == children.size() -1) || (getWidgetIndex(w) == getWidgetCount() -1);
         if(isLastWidget && getWidgetCount() > 0) {
             Widget l = getWidget(getWidgetCount() -1);
             super.remove(l);

--- a/src/main/java/com/github/gwtbootstrap/client/ui/ButtonToolbar.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/ButtonToolbar.java
@@ -79,12 +79,11 @@ public class ButtonToolbar extends DivWidget {
 	@Override
 	public void add(Widget widget) {
 
-		Widget addingWidget = widget;
-
 		if (!canBeAdded(widget))
 			throw new IllegalArgumentException("A widget of "
 					+ widget.getClass() + " cannot be added to the toolbar.");
 
+		Widget addingWidget = widget;
 		if (widget instanceof Button)
 			addingWidget = new ButtonGroup((Button) widget);
 

--- a/src/main/java/com/github/gwtbootstrap/client/ui/CheckBox.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/CheckBox.java
@@ -557,14 +557,6 @@ public class CheckBox extends ButtonBase implements HasName, HasValue<Boolean>, 
 	 */
 	protected void replaceInputElement(Element elem) {
 		InputElement newInputElem = InputElement.as(elem);
-		// Collect information we need to set
-		int tabIndex = getTabIndex();
-		boolean checked = getValue();
-		boolean enabled = isEnabled();
-		String formValue = getFormValue();
-		String uid = inputElem.getId();
-		String accessKey = inputElem.getAccessKey();
-		int sunkEvents = Event.getEventsSunk(inputElem);
 
 		// Clear out the old input element
 		setEventListener(asOld(inputElem), null);
@@ -575,6 +567,10 @@ public class CheckBox extends ButtonBase implements HasName, HasValue<Boolean>, 
 		Event.sinkEvents(elem, Event.getEventsSunk(inputElem));
 		Event.sinkEvents(inputElem, 0);
 		inputElem = newInputElem;
+		
+		String uid = inputElem.getId();
+		String accessKey = inputElem.getAccessKey();
+		int sunkEvents = Event.getEventsSunk(inputElem);
 
 		// Setup the new element
 		Event.sinkEvents(inputElem, sunkEvents);
@@ -582,6 +578,13 @@ public class CheckBox extends ButtonBase implements HasName, HasValue<Boolean>, 
 		if (!"".equals(accessKey)) {
 			inputElem.setAccessKey(accessKey);
 		}
+
+		// Collect information we need to set
+		int tabIndex = getTabIndex();
+		boolean checked = getValue();
+		boolean enabled = isEnabled();
+		String formValue = getFormValue();
+
 		setTabIndex(tabIndex);
 		setValue(checked);
 		setEnabled(enabled);

--- a/src/showcase/java/com/github/gwtbootstrap/showcase/client/Alerts.java
+++ b/src/showcase/java/com/github/gwtbootstrap/showcase/client/Alerts.java
@@ -119,14 +119,6 @@ public class Alerts extends Composite {
     @UiHandler("showButton")
     public void onClickShowButton(ClickEvent e) {
         
-        ClosedHandler handler = new ClosedHandler() {
-            
-            @Override
-            public void onClosed(ClosedEvent closedEvent) {
-                onHiddenAlert(closedEvent);
-            }
-        };
-        
         if(setupAlert.getElement().hasParentElement())
             setupAlert.removeFromParent();
         
@@ -136,7 +128,16 @@ public class Alerts extends Composite {
         AlertBase backup = setupAlert;
         
         setupAlert = new Alert();
-        
+
+        ClosedHandler handler = new ClosedHandler() {
+
+            @Override
+            public void onClosed(ClosedEvent closedEvent) {
+                onHiddenAlert(closedEvent);
+            }
+        };
+
+
         setupAlert.setText(backup.getText());
         setupAlert.setClose(backup.hasClose());
         setupAlert.setHeading(heading.getText());


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1941 - Variables should not be declared before they are relevant

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1941

Please let me know if you have any questions.

M-Ezzat