### PR TITLE
squid:S1170, squid:S1155 - Public constants~~~, Collection.isEmpty() …

### DIFF
--- a/src/main/java/com/github/gwtbootstrap/client/ui/Form.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/Form.java
@@ -242,7 +242,7 @@ public class Form extends ComplexWidget implements FormPanelImplHost {
 		FormElement.as(element);
 
 		if (createIFrame) {
-			assert (getTarget() == null || getTarget().trim().length() == 0) : "Cannot create target iframe if the form's target is already set.";
+			assert (getTarget() == null || getTarget().trim().isEmpty()) : "Cannot create target iframe if the form's target is already set.";
 
 			// We use the module name as part of the unique ID to ensure that
 			// ids are

--- a/src/main/java/com/github/gwtbootstrap/client/ui/Modal.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/Modal.java
@@ -91,7 +91,7 @@ public class Modal extends DivWidget implements HasVisibility, HasVisibleHandler
 
     private BackdropType backdropType = BackdropType.NORMAL;
 
-    private final boolean show = false;
+    private static final boolean show = false;
 
     private boolean hideOthers = true;
 

--- a/src/main/java/com/github/gwtbootstrap/client/ui/Scrollspy.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/Scrollspy.java
@@ -51,7 +51,7 @@ public class Scrollspy {
 		super();
 		this.navbar = navbar;
 		
-		if(navbar.getId() != null && navbar.getId().length() > 0) {
+		if(navbar.getId() != null && !navbar.getId().isEmpty()) {
 			setTarget("#" + navbar.getId());
 		}
 	}

--- a/src/main/java/com/github/gwtbootstrap/client/ui/SimplePager.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/SimplePager.java
@@ -94,9 +94,9 @@ public class SimplePager extends AbstractPager {
 
     private static final int DEFAULT_FAST_FORWARD_ROWS = 100;
     private static Resources DEFAULT_RESOURCES;
-    private final int tooltipDelay = 1000;
+    private static final int tooltipDelay = 1000;
     
-    private final Placement tooltipPlacement = Placement.BOTTOM;
+    private static final Placement tooltipPlacement = Placement.BOTTOM;
 
     private final Button fastForward;
     private final Tooltip fastForwardTooltip;

--- a/src/main/java/com/github/gwtbootstrap/datetimepicker/client/ui/base/DateTimeBoxBase.java
+++ b/src/main/java/com/github/gwtbootstrap/datetimepicker/client/ui/base/DateTimeBoxBase.java
@@ -657,7 +657,7 @@ public class DateTimeBoxBase
 
     private String dpGlobalFormatToDateTimeFormat(String dpGlobalFormat)
     {
-        if(dpGlobalFormat == null || dpGlobalFormat.length() == 0)
+        if(dpGlobalFormat == null || dpGlobalFormat.isEmpty())
             return "";
 
         char current;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules squid:S1170 - Public constants and fields initialized at declaration should be "static final" rather than merely "final"
squid:S1155 - Collection.isEmpty() should be used to test for emptiness

You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1170
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1155

Please let me know if you have any questions.

M-Ezzat