### PR TITLE
Fix Deprecated Element/DOM usage

### DIFF
--- a/src/main/java/com/github/gwtbootstrap/client/ui/Abbreviation.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/Abbreviation.java
@@ -17,8 +17,8 @@ package com.github.gwtbootstrap.client.ui;
 
 import com.github.gwtbootstrap.client.ui.base.AbstractTypography;
 import com.github.gwtbootstrap.client.ui.constants.Constants;
+import com.google.gwt.dom.client.Document;
 import com.google.gwt.uibinder.client.UiConstructor;
-import com.google.gwt.user.client.DOM;
 
 /**
  * A text element that shows more information in a tooltip.
@@ -64,7 +64,7 @@ public class Abbreviation extends AbstractTypography {
 	 */
 	public @UiConstructor
 	Abbreviation(String title) {
-		setElement(DOM.createElement("abbr"));
+		setElement(Document.get().createElement("abbr"));
 		setTitle(title);
 	}
 

--- a/src/main/java/com/github/gwtbootstrap/client/ui/Affix.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/Affix.java
@@ -79,7 +79,7 @@ public class Affix extends AbstractMarkupWidget {
     
     
     public void reconfigure() {
-        com.google.gwt.user.client.Element element = getWidget().getElement();
+        Element element = getWidget().getElement();
         removeDataIfExists(element);
         configure(element);
     }

--- a/src/main/java/com/github/gwtbootstrap/client/ui/Blockquote.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/Blockquote.java
@@ -17,7 +17,7 @@ package com.github.gwtbootstrap.client.ui;
 
 import com.github.gwtbootstrap.client.ui.base.AbstractTypography;
 import com.github.gwtbootstrap.client.ui.constants.Alignment;
-import com.google.gwt.user.client.DOM;
+import com.google.gwt.dom.client.Document;
 
 //@formatter:off
 /**
@@ -46,7 +46,7 @@ public class Blockquote extends AbstractTypography {
 	 * Creates an empty Blockquote.
 	 */
 	public Blockquote() {
-		setElement(DOM.createElement("blockquote"));
+		setElement(Document.get().createElement("blockquote"));
 	}
 
 	/**
@@ -146,7 +146,7 @@ public class Blockquote extends AbstractTypography {
 		 *            the text to be set
 		 */
 		public Cite(String text) {
-			setElement(DOM.createElement("cite"));
+			setElement(Document.get().createElement("cite"));
 			setText(text);
 		}
 	}
@@ -163,7 +163,7 @@ public class Blockquote extends AbstractTypography {
 		private final Cite cite;
 
 		public SmallCite(String text) {
-			setElement(DOM.createElement("small"));
+			setElement(Document.get().createElement("small"));
 			this.cite = new Cite(text);
 			getElement().appendChild(cite.getElement());
 		}

--- a/src/main/java/com/github/gwtbootstrap/client/ui/CheckBox.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/CheckBox.java
@@ -15,6 +15,9 @@
  */
 package com.github.gwtbootstrap.client.ui;
 
+import static com.github.gwtbootstrap.client.ui.constants.Constants.CHECKBOX;
+import static com.github.gwtbootstrap.client.ui.constants.Constants.RADIO;
+
 import com.github.gwtbootstrap.client.ui.base.HasId;
 import com.github.gwtbootstrap.client.ui.base.HasStyle;
 import com.github.gwtbootstrap.client.ui.base.IsResponsive;
@@ -26,6 +29,7 @@ import com.github.gwtbootstrap.client.ui.base.StyleHelper;
 import com.github.gwtbootstrap.client.ui.constants.Constants;
 import com.github.gwtbootstrap.client.ui.constants.Device;
 import com.google.gwt.dom.client.Document;
+import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.InputElement;
 import com.google.gwt.dom.client.LabelElement;
 import com.google.gwt.dom.client.SpanElement;
@@ -42,9 +46,7 @@ import com.google.gwt.i18n.shared.DirectionEstimator;
 import com.google.gwt.i18n.shared.HasDirectionEstimator;
 import com.google.gwt.safehtml.shared.SafeHtml;
 import com.google.gwt.user.client.DOM;
-import com.google.gwt.dom.client.Element;
 import com.google.gwt.user.client.Event;
-import com.google.gwt.user.client.EventListener;
 import com.google.gwt.user.client.ui.ButtonBase;
 import com.google.gwt.user.client.ui.DirectionalTextHelper;
 import com.google.gwt.user.client.ui.FormPanel;
@@ -55,9 +57,6 @@ import com.google.gwt.user.client.ui.HasWordWrap;
 import com.google.gwt.user.client.ui.RadioButton;
 import com.google.gwt.user.client.ui.UIObject;
 import com.google.gwt.user.client.ui.Widget;
-
-import static com.github.gwtbootstrap.client.ui.constants.Constants.CHECKBOX;
-import static com.github.gwtbootstrap.client.ui.constants.Constants.RADIO;
 
 /**
  * CheckBox widgets.
@@ -97,7 +96,7 @@ public class CheckBox extends ButtonBase implements HasName, HasValue<Boolean>, 
 	 * Creates a check box with no label.
 	 */
 	public CheckBox() {
-		this(DOM.createInputCheck());
+		this(Document.get().createCheckInputElement());
 	}
 
 	/**
@@ -531,7 +530,7 @@ public class CheckBox extends ButtonBase implements HasName, HasValue<Boolean>, 
 	 */
 	@Override
 	protected void onLoad() {
-		setEventListener(inputElem, this);
+		DOM.setEventListener(inputElem, this);
 	}
 
 	/**
@@ -543,7 +542,7 @@ public class CheckBox extends ButtonBase implements HasName, HasValue<Boolean>, 
 	protected void onUnload() {
 		// Clear out the inputElem's event listener (breaking the circular
 		// reference between it and the widget).
-		setEventListener(asOld(inputElem), null);
+		DOM.setEventListener(inputElem, null);
 		setValue(getValue());
 	}
 
@@ -559,7 +558,7 @@ public class CheckBox extends ButtonBase implements HasName, HasValue<Boolean>, 
 		InputElement newInputElem = InputElement.as(elem);
 
 		// Clear out the old input element
-		setEventListener(asOld(inputElem), null);
+		DOM.setEventListener(inputElem, null);
 
 		getElement().replaceChild(newInputElem, inputElem);
 
@@ -592,17 +591,8 @@ public class CheckBox extends ButtonBase implements HasName, HasValue<Boolean>, 
 
 		// Set the event listener
 		if (isAttached()) {
-			setEventListener(asOld(inputElem), this);
+			DOM.setEventListener(inputElem, this);
 		}
-	}
-
-	private Element asOld(com.google.gwt.dom.client.Element elem) {
-		Element oldSchool = elem.cast();
-		return oldSchool;
-	}
-
-	private void setEventListener(com.google.gwt.dom.client.Element e, EventListener listener) {
-		DOM.setEventListener(asOld(e), listener);
 	}
 
 	protected LabelElement asLabel() {

--- a/src/main/java/com/github/gwtbootstrap/client/ui/CheckBox.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/CheckBox.java
@@ -42,7 +42,7 @@ import com.google.gwt.i18n.shared.DirectionEstimator;
 import com.google.gwt.i18n.shared.HasDirectionEstimator;
 import com.google.gwt.safehtml.shared.SafeHtml;
 import com.google.gwt.user.client.DOM;
-import com.google.gwt.user.client.Element;
+import com.google.gwt.dom.client.Element;
 import com.google.gwt.user.client.Event;
 import com.google.gwt.user.client.EventListener;
 import com.google.gwt.user.client.ui.ButtonBase;

--- a/src/main/java/com/github/gwtbootstrap/client/ui/Code.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/Code.java
@@ -18,8 +18,8 @@ package com.github.gwtbootstrap.client.ui;
 import com.github.gwtbootstrap.client.ui.base.AbstractTypography;
 import com.github.gwtbootstrap.client.ui.resources.prettify.HasProgrammingLanguage;
 import com.github.gwtbootstrap.client.ui.resources.prettify.PrettifyHelper;
+import com.google.gwt.dom.client.Document;
 import com.google.gwt.safehtml.shared.SafeHtmlUtils;
-import com.google.gwt.user.client.DOM;
 import com.google.gwt.user.client.ui.HasHTML;
 
 //@formatter:off
@@ -54,7 +54,7 @@ public class Code extends AbstractTypography implements HasProgrammingLanguage,
 	 * Creates an empty widget.
 	 */
 	public Code() {
-		setElement(DOM.createElement("code"));
+		setElement(Document.get().createElement("code"));
 		helper = new PrettifyHelper(this);
 	}
 

--- a/src/main/java/com/github/gwtbootstrap/client/ui/CollapseTrigger.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/CollapseTrigger.java
@@ -7,7 +7,7 @@ import com.google.gwt.core.client.Scheduler.ScheduledCommand;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.event.dom.client.HasClickHandlers;
-import com.google.gwt.user.client.Element;
+import com.google.gwt.dom.client.Element;
 import com.google.gwt.user.client.ui.Widget;
 
 /**

--- a/src/main/java/com/github/gwtbootstrap/client/ui/Emphasis.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/Emphasis.java
@@ -16,7 +16,7 @@
 package com.github.gwtbootstrap.client.ui;
 
 import com.github.gwtbootstrap.client.ui.base.AbstractTypography;
-import com.google.gwt.user.client.DOM;
+import com.google.gwt.dom.client.Document;
 
 //@formatter:off
 /**
@@ -45,7 +45,7 @@ public class Emphasis extends AbstractTypography {
 	 * Creates an empty widget.
 	 */
 	public Emphasis() {
-		setElement(DOM.createElement("em"));
+		setElement(Document.get().createElement("em"));
 	}
 
 	/**

--- a/src/main/java/com/github/gwtbootstrap/client/ui/Icon.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/Icon.java
@@ -24,8 +24,8 @@ import com.github.gwtbootstrap.client.ui.constants.IconFlip;
 import com.github.gwtbootstrap.client.ui.constants.IconRotate;
 import com.github.gwtbootstrap.client.ui.constants.IconSize;
 import com.github.gwtbootstrap.client.ui.constants.IconType;
+import com.google.gwt.dom.client.Document;
 import com.google.gwt.uibinder.client.UiConstructor;
-import com.google.gwt.user.client.DOM;
 import com.google.gwt.user.client.ui.Widget;
 
 //@formatter:off
@@ -66,7 +66,7 @@ public class Icon extends Widget implements HasAlignment {
      * (This is probably not what you want to do most of the time.)
      */
     public Icon() {
-        setElement(DOM.createElement("i"));
+        setElement(Document.get().createElement("i"));
     }
 
     /**

--- a/src/main/java/com/github/gwtbootstrap/client/ui/IconStack.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/IconStack.java
@@ -16,7 +16,7 @@
 package com.github.gwtbootstrap.client.ui;
 
 import com.github.gwtbootstrap.client.ui.constants.Constants;
-import com.google.gwt.user.client.DOM;
+import com.google.gwt.dom.client.Document;
 import com.google.gwt.user.client.ui.ComplexPanel;
 import com.google.gwt.user.client.ui.Widget;
 
@@ -46,7 +46,7 @@ import com.google.gwt.user.client.ui.Widget;
 public class IconStack extends ComplexPanel {
 
     public IconStack() {
-        setElement(DOM.createSpan());
+        setElement(Document.get().createSpanElement());
         getElement().addClassName(Constants.ICON_STACK);
     }
 

--- a/src/main/java/com/github/gwtbootstrap/client/ui/ListBox.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/ListBox.java
@@ -65,13 +65,13 @@ public class ListBox extends com.google.gwt.user.client.ui.ListBox implements Ha
 	}
 
 	/**
-	 * Creates an empty list box. The preferred way to enable multiple
-	 * selections is to use this constructor rather than
-	 * {@link #setMultipleSelect(boolean)}.
+	 * Creates an empty list box.
 	 * 
 	 * @param isMultipleSelect
 	 *            specifies if multiple selection is enabled
+	 * @deprecated use {@link #setMultipleSelect(boolean)} instead.
 	 */
+	@Deprecated
 	public ListBox(boolean isMultipleSelect) {
 		super(isMultipleSelect);
 	}

--- a/src/main/java/com/github/gwtbootstrap/client/ui/Modal.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/Modal.java
@@ -36,7 +36,6 @@ import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.Style;
 import com.google.gwt.event.shared.HandlerRegistration;
-import com.google.gwt.user.client.DOM;
 import com.google.gwt.user.client.Event;
 import com.google.gwt.user.client.ui.PopupPanel;
 import com.google.gwt.user.client.ui.RootPanel;
@@ -619,8 +618,8 @@ public class Modal extends DivWidget implements HasVisibility, HasVisibleHandler
      * @param width Modal's new width, in px
      */
     public void setWidth(int width) {
-        DOM.setStyleAttribute(this.getElement(), "width", width + "px");
-        DOM.setStyleAttribute(this.getElement(), "marginLeft", (-width / 2) + "px");
+        this.getElement().getStyle().setProperty("width", width + "px");
+        this.getElement().getStyle().setProperty("marginLeft", (-width / 2) + "px");
     }
 
     /**
@@ -629,7 +628,7 @@ public class Modal extends DivWidget implements HasVisibility, HasVisibleHandler
      * @param maxHeight the Modal's body new maxHeight, in CSS units (e.g. "10px", "1em")
      */
     public void setMaxHeigth(String maxHeight) {
-        DOM.setStyleAttribute(body.getElement(), "maxHeight", maxHeight);
+        body.getElement().getStyle().setProperty("maxHeight", maxHeight);
     }
 
 }

--- a/src/main/java/com/github/gwtbootstrap/client/ui/Navbar.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/Navbar.java
@@ -20,7 +20,7 @@ import com.github.gwtbootstrap.client.ui.constants.Constants;
 import com.github.gwtbootstrap.client.ui.constants.NavbarConstants;
 import com.github.gwtbootstrap.client.ui.constants.NavbarPosition;
 import com.google.gwt.dom.client.Document;
-import com.google.gwt.user.client.Element;
+import com.google.gwt.dom.client.Element;
 import com.google.gwt.user.client.ui.RootPanel;
 import com.google.gwt.user.client.ui.Widget;
 

--- a/src/main/java/com/github/gwtbootstrap/client/ui/Strong.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/Strong.java
@@ -16,7 +16,7 @@
 package com.github.gwtbootstrap.client.ui;
 
 import com.github.gwtbootstrap.client.ui.base.AbstractTypography;
-import com.google.gwt.user.client.DOM;
+import com.google.gwt.dom.client.Document;
 
 //@formatter:off
 /**
@@ -35,7 +35,7 @@ public class Strong extends AbstractTypography {
 	 * Creates a new widget.
 	 */
 	public Strong() {
-		setElement(DOM.createElement("strong"));
+		setElement(Document.get().createElement("strong"));
 	}
 
 	/**

--- a/src/main/java/com/github/gwtbootstrap/client/ui/TabLink.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/TabLink.java
@@ -19,7 +19,7 @@ import com.github.gwtbootstrap.client.ui.constants.Constants;
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.core.client.Scheduler.ScheduledCommand;
 import com.google.gwt.user.client.DOM;
-import com.google.gwt.user.client.Element;
+import com.google.gwt.dom.client.Element;
 import com.google.gwt.user.client.ui.HasEnabled;
 
 /**

--- a/src/main/java/com/github/gwtbootstrap/client/ui/Typeahead.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/Typeahead.java
@@ -1,12 +1,14 @@
 package com.github.gwtbootstrap.client.ui;
 
+import java.util.Collection;
+
 import com.github.gwtbootstrap.client.ui.base.AbstractMarkupWidget;
 import com.github.gwtbootstrap.client.ui.base.TextBoxBase;
 import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.core.client.JsArrayString;
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.core.client.Scheduler.ScheduledCommand;
-import com.google.gwt.user.client.Element;
+import com.google.gwt.dom.client.Element;
 import com.google.gwt.user.client.ui.HTML;
 import com.google.gwt.user.client.ui.MultiWordSuggestOracle;
 import com.google.gwt.user.client.ui.SuggestOracle;
@@ -15,7 +17,6 @@ import com.google.gwt.user.client.ui.SuggestOracle.Request;
 import com.google.gwt.user.client.ui.SuggestOracle.Response;
 import com.google.gwt.user.client.ui.SuggestOracle.Suggestion;
 import com.google.gwt.user.client.ui.Widget;
-import java.util.Collection;
 
 public class Typeahead extends AbstractMarkupWidget {
 

--- a/src/main/java/com/github/gwtbootstrap/client/ui/base/AbstractTypography.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/base/AbstractTypography.java
@@ -16,7 +16,7 @@
 package com.github.gwtbootstrap.client.ui.base;
 
 import com.github.gwtbootstrap.client.ui.constants.Device;
-import com.google.gwt.user.client.DOM;
+import com.google.gwt.dom.client.Document;
 import com.google.gwt.user.client.ui.HasText;
 import com.google.gwt.user.client.ui.Widget;
 
@@ -45,7 +45,7 @@ public abstract class AbstractTypography extends Widget implements HasText,
 	 *            the HTML tag to be used
 	 */
 	public AbstractTypography(String tag) {
-		setElement(DOM.createElement(tag));
+		setElement(Document.get().createElement(tag));
 	}
 
 	/**

--- a/src/main/java/com/github/gwtbootstrap/client/ui/base/Caret.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/base/Caret.java
@@ -18,7 +18,7 @@ package com.github.gwtbootstrap.client.ui.base;
 import com.github.gwtbootstrap.client.ui.Dropdown;
 import com.github.gwtbootstrap.client.ui.DropdownButton;
 import com.github.gwtbootstrap.client.ui.constants.Constants;
-import com.google.gwt.user.client.DOM;
+import com.google.gwt.dom.client.Document;
 
 /**
  * Icon used in Dropdowns to show the presence of a menu. Can point up- or
@@ -54,7 +54,7 @@ public class Caret extends AbstractTypography {
 	 *            <code>true</code>
 	 */
 	public Caret(boolean visible) {
-		setElement(DOM.createElement("span"));
+		setElement(Document.get().createSpanElement());
 		if (visible)
 			show();
 	}

--- a/src/main/java/com/github/gwtbootstrap/client/ui/base/ComplexWidget.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/base/ComplexWidget.java
@@ -16,7 +16,7 @@
 package com.github.gwtbootstrap.client.ui.base;
 
 import com.github.gwtbootstrap.client.ui.constants.Device;
-import com.google.gwt.user.client.DOM;
+import com.google.gwt.dom.client.Document;
 import com.google.gwt.user.client.ui.ComplexPanel;
 import com.google.gwt.user.client.ui.HasWidgets;
 import com.google.gwt.user.client.ui.Widget;
@@ -40,7 +40,7 @@ public class ComplexWidget extends ComplexPanel implements HasWidgets,
 	 *            the html tag used for this widget
 	 */
 	public ComplexWidget(String tag) {
-		setElement(DOM.createElement(tag));
+		setElement(Document.get().createElement(tag));
 	}
 
 	/**

--- a/src/main/java/com/github/gwtbootstrap/client/ui/base/IconAnchor.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/base/IconAnchor.java
@@ -242,7 +242,7 @@ public class IconAnchor extends ComplexWidget implements HasText, HasIcon, HasHr
 	 */
 	@Override
 	public boolean isEnabled() {
-		return !DOM.getElementPropertyBoolean(getElement(), "disabled");
+		return !getElement().getPropertyBoolean("disabled");
 	}
 
 	/**
@@ -250,7 +250,7 @@ public class IconAnchor extends ComplexWidget implements HasText, HasIcon, HasHr
 	 */
 	@Override
 	public void setEnabled(boolean enabled) {
-		DOM.setElementPropertyBoolean(getElement(), "disabled", !enabled);
+		getElement().setPropertyBoolean("disabled", !enabled);
 	}
 
 	/**
@@ -278,7 +278,7 @@ public class IconAnchor extends ComplexWidget implements HasText, HasIcon, HasHr
 
     @Override
     public void setAccessKey(char key) {
-    	DOM.setElementProperty(getElement(), "accessKey", Character.toString(key));
+    	getElement().setPropertyString("accessKey", Character.toString(key));
     }
 
     @Override

--- a/src/main/java/com/github/gwtbootstrap/client/ui/base/PlaceholderHelper.java
+++ b/src/main/java/com/github/gwtbootstrap/client/ui/base/PlaceholderHelper.java
@@ -16,7 +16,7 @@
 package com.github.gwtbootstrap.client.ui.base;
 
 import com.github.gwtbootstrap.client.ui.constants.Constants;
-import com.google.gwt.user.client.Element;
+import com.google.gwt.dom.client.Element;
 
 
 /**

--- a/src/main/java/com/github/gwtbootstrap/timepicker/client/ui/TimeBoxAppended.java
+++ b/src/main/java/com/github/gwtbootstrap/timepicker/client/ui/TimeBoxAppended.java
@@ -192,6 +192,10 @@ public class TimeBoxAppended extends AppendButton implements HasValue<Date>, Has
         icon.setCustomIconStyle(customIconStyle);
     }
 
+    /**
+     * @deprecated
+     */
+    @Deprecated
     @Override
     public void setIconPosition(IconPosition position) {
         icon.setIconPosition(position);

--- a/src/main/webapp/WEB-INF/.gitignore
+++ b/src/main/webapp/WEB-INF/.gitignore
@@ -1,0 +1,1 @@
+/classes/

--- a/src/showcase/java/com/github/gwtbootstrap/showcase/client/Subnav.java
+++ b/src/showcase/java/com/github/gwtbootstrap/showcase/client/Subnav.java
@@ -24,7 +24,7 @@ import com.github.gwtbootstrap.client.ui.base.HasId;
 import com.github.gwtbootstrap.client.ui.base.IconAnchor;
 import com.github.gwtbootstrap.client.ui.constants.Constants;
 import com.google.gwt.user.client.DOM;
-import com.google.gwt.user.client.Element;
+import com.google.gwt.dom.client.Element;
 import com.google.gwt.user.client.ui.Widget;
 
 public class Subnav extends DivWidget implements HasId {


### PR DESCRIPTION
Mostly DOM.createElement() to Document.get().createElement().

Takes the warnings count down to 10 on my system.
